### PR TITLE
Add Google Play services metadata and update dependencies

### DIFF
--- a/src-capacitor/android/app/build.gradle
+++ b/src-capacitor/android/app/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
+    implementation "com.google.android.gms:play-services-base:$playServicesVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/src-capacitor/android/app/src/main/AndroidManifest.xml
+++ b/src-capacitor/android/app/src/main/AndroidManifest.xml
@@ -33,6 +33,10 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths"></meta-data>
         </provider>
+
+        <meta-data
+            android:name="com.google.android.gms.version"
+            android:value="@integer/google_play_services_version" />
     </application>
 
     <!-- Permissions -->

--- a/src-capacitor/android/variables.gradle
+++ b/src-capacitor/android/variables.gradle
@@ -13,4 +13,5 @@ ext {
     androidxJunitVersion = '1.2.1'
     androidxEspressoCoreVersion = '3.6.1'
     cordovaAndroidVersion = '10.1.1'
+    playServicesVersion = '18.3.0'
 }


### PR DESCRIPTION
Problem
When pressing the send button on GrapheneOS, the app crashed with the following error:
`com.google.android.gms.common.GooglePlayServicesMissingManifestValueException: 
A required meta-data tag in your app's AndroidManifest.xml does not exist. 
You must have the following declaration within the <application> element:
<meta-data android:name="com.google.android.gms.version" 
           android:value="@integer/google_play_services_version" />`
          
The barcode detection feature (camera/QR code scanning triggered by the send button) requires Google Play Services, which was not properly configured.

Root Cause
The application was missing:
Required Google Play Services meta-data declaration in AndroidManifest.xml
Google Play Services dependency in build.gradle