### PR TITLE
shows the min/max range for variable-amount payments

### DIFF
--- a/src/i18n/de/index.js
+++ b/src/i18n/de/index.js
@@ -725,6 +725,7 @@ export default {
   "Sats received!": "Sats erhalten!",
   "Redeem failed": "Einlösen fehlgeschlagen",
   "Redeemable": "Einlösbar",
+  "Amount range": "Betragsbereich",
   "Enter amount": "Betrag eingeben",
   "Scan to redeem": "Scannen zum Einlösen",
   "Payment expired": "Zahlung abgelaufen",

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -755,6 +755,7 @@ export default {
   "Sats received!": "Sats received!",
   "Redeem failed": "Redeem failed",
   "Redeemable": "Redeemable",
+  "Amount range": "Amount range",
   "Enter amount": "Enter amount",
   "Scan to redeem": "Scan to redeem",
 

--- a/src/i18n/es/index.js
+++ b/src/i18n/es/index.js
@@ -725,6 +725,7 @@ export default {
   "Sats received!": "Sats recibidos!",
   "Redeem failed": "Canje fallido",
   "Redeemable": "Canjeable",
+  "Amount range": "Rango de monto",
   "Enter amount": "Ingrese monto",
   "Scan to redeem": "Escanear para canjear",
   "Payment expired": "Pago expirado",

--- a/src/pages/Wallet.vue
+++ b/src/pages/Wallet.vue
@@ -502,6 +502,11 @@
                   <span v-else-if="pendingPayment.sparkAddress" class="fee-free">{{ $t('Free (Spark transfer)') }}</span>
                 </span>
               </div>
+              <!-- Amount range for variable-amount payments -->
+              <div class="detail-item" v-if="payAmountRange">
+                <span class="detail-label" :class="$q.dark.isActive ? 'detail_label_dark' : 'detail_label_light'">{{ $t('Amount range') }}:</span>
+                <span class="detail-value" :class="$q.dark.isActive ? 'detail_value_dark' : 'detail_value_light'">{{ payAmountRange }}</span>
+              </div>
             </div>
 
             <!-- Amount input for LNURL/Lightning Address -->
@@ -913,6 +918,19 @@ export default {
         }
       }
       return `${this.pendingPayment.minSats} - ${this.pendingPayment.maxSats} sats`;
+    },
+    payAmountRange() {
+      if (!this.pendingPayment || !this.needsAmountInput) return '';
+      const minSats = this.pendingPayment.minSats || (this.pendingPayment.minSendable ? Math.ceil(this.pendingPayment.minSendable / 1000) : 0);
+      const maxSats = this.pendingPayment.maxSats || (this.pendingPayment.maxSendable ? Math.floor(this.pendingPayment.maxSendable / 1000) : 0);
+      if (!minSats || !maxSats || minSats === maxSats) return '';
+      const currency = this.withdrawFiatCurrency;
+      const minFiat = fiatRatesService.convertSatsToFiatSync(minSats, currency);
+      const maxFiat = fiatRatesService.convertSatsToFiatSync(maxSats, currency);
+      if (minFiat !== null && maxFiat !== null) {
+        return `${fiatRatesService.formatFiatAmount(minFiat, currency)} - ${fiatRatesService.formatFiatAmount(maxFiat, currency)} (${minSats} - ${maxSats} sats)`;
+      }
+      return `${minSats} - ${maxSats} sats`;
     },
     canConfirmWithdraw() {
       if (!this.pendingPayment || this.pendingPayment.type !== 'lnurl_withdraw') return false;


### PR DESCRIPTION
(LNURL-pay, lightning address,paycodes). It displays both fiat and sats when fiat rates are available (e.g. /opt/homebrew/bin/zsh.50 - .00 (50 - 500 sats))