### PR TITLE
lud17 check - return null which fallback to bech32

### DIFF
--- a/src/components/PaymentModal.vue
+++ b/src/components/PaymentModal.vue
@@ -154,7 +154,7 @@
 <script>
 import { useWalletStore } from '../stores/wallet'
 import { mapState } from 'pinia'
-import LightningPaymentService from '../utils/lightning.js'
+import LightningPaymentService, { resolveLUD17URL } from '../utils/lightning.js'
 import { fiatRatesService } from '../utils/fiatRates.js'
 import { formatAmount } from '../utils/amountFormatting.js'
 
@@ -598,7 +598,7 @@ export default {
 
     isLNURL(input) {
       const lower = input.toLowerCase()
-      return lower.startsWith('lnurl')
+      return lower.startsWith('lnurl') || lower.startsWith('keyauth://')
     },
 
     async fetchLNURLInvoice(lnurl, amountSats) {
@@ -680,10 +680,14 @@ export default {
     },
 
     decodeLNURL(lnurl) {
-      // Remove prefix if present
-      const input = lnurl.toLowerCase().replace('lightning:', '')
+      const clean = lnurl.trim().replace(/^lightning:/i, '')
 
-      // Bech32 character set
+      // LUD-17: lnurlp://, lnurlw://, lnurlc://, keyauth://
+      const lud17Url = resolveLUD17URL(clean)
+      if (lud17Url) return lud17Url
+
+      // LUD-01: bech32-encoded LNURL
+      const input = clean.toLowerCase()
       const CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
       const hrpEnd = input.lastIndexOf('1')
       if (hrpEnd < 1) throw new Error('Invalid LNURL')

--- a/src/components/SendModal.vue
+++ b/src/components/SendModal.vue
@@ -664,7 +664,7 @@ export default {
       if (cleanData.startsWith('lnbc') || cleanData.startsWith('lntb') ||
           cleanData.startsWith('lntbs') || cleanData.startsWith('lnbcrt')) return 'lightning_invoice';
       if (cleanData.includes('@') && cleanData.includes('.')) return 'lightning_address';
-      if (cleanData.startsWith('lnurl')) return 'lnurl';
+      if (cleanData.startsWith('lnurl') || cleanData.startsWith('keyauth://')) return 'lnurl';
       // Bitcoin on-chain addresses (L1)
       if (this.isBitcoinAddress(cleanData)) return 'bitcoin_address';
       return 'unknown';

--- a/src/pages/Wallet.vue
+++ b/src/pages/Wallet.vue
@@ -645,7 +645,7 @@
 
 <script>
 import { NostrWebLNProvider } from "@getalby/sdk";
-import {LightningPaymentService} from '../utils/lightning.js';
+import {LightningPaymentService, resolveLUD17URL} from '../utils/lightning.js';
 import {Invoice} from '@getalby/lightning-tools';
 import {fiatRatesService} from '../utils/fiatRates.js';
 import {formatMainBalance as formatMainBalanceUtil, formatAmount} from '../utils/amountFormatting.js';
@@ -2756,7 +2756,7 @@ export default {
     // Helper: Check if input is an LNURL
     isLNURL(input) {
       const lower = input.toLowerCase();
-      return lower.startsWith('lnurl');
+      return lower.startsWith('lnurl') || lower.startsWith('keyauth://');
     },
 
     // Helper: Get recipient address from pending payment
@@ -3044,9 +3044,16 @@ export default {
       }
     },
 
-    // Helper: Decode LNURL (bech32) to URL
+    // Helper: Decode LNURL (bech32 LUD-01 or URL scheme LUD-17) to URL
     decodeLNURL(lnurl) {
-      const input = lnurl.toLowerCase().replace('lightning:', '');
+      const clean = lnurl.trim().replace(/^lightning:/i, '');
+
+      // LUD-17: lnurlp://, lnurlw://, lnurlc://, keyauth://
+      const lud17Url = resolveLUD17URL(clean);
+      if (lud17Url) return lud17Url;
+
+      // LUD-01: bech32-encoded LNURL
+      const input = clean.toLowerCase();
       const CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
       const hrpEnd = input.lastIndexOf('1');
       if (hrpEnd < 1) throw new Error('Invalid LNURL');

--- a/src/providers/WalletFactory.js
+++ b/src/providers/WalletFactory.js
@@ -164,8 +164,10 @@ export function parsePaymentDestination(input) {
     }
   }
 
-  // LNURL (bech32 encoded)
-  if (normalized.startsWith('lnurl1')) {
+  // LNURL (bech32 LUD-01 or URL scheme LUD-17)
+  if (normalized.startsWith('lnurl1') || normalized.startsWith('lnurlp://') ||
+      normalized.startsWith('lnurlw://') || normalized.startsWith('lnurlc://') ||
+      normalized.startsWith('keyauth://')) {
     return {
       type: 'lnurl',
       lnurl: cleaned,

--- a/src/utils/lightning.js
+++ b/src/utils/lightning.js
@@ -14,6 +14,36 @@ import { LightningAddress, Invoice } from '@getalby/lightning-tools';
 import { bech32 } from 'bech32';
 
 /**
+ * LUD-17 URL scheme prefixes mapped to their LNURL type.
+ * @see https://github.com/lnurl/luds/blob/luds/17.md
+ */
+const LUD17_SCHEMES = {
+  'lnurlp://': 'payRequest',
+  'lnurlw://': 'withdrawRequest',
+  'lnurlc://': 'channelRequest',
+  'keyauth://': 'login',
+};
+
+/**
+ * Resolves a LUD-17 URL scheme to a standard HTTPS (or HTTP for .onion) URL.
+ * Returns null if the input is not a LUD-17 URL.
+ * @param {string} input - The input string to check
+ * @returns {string|null} The resolved URL, or null if not LUD-17
+ */
+export function resolveLUD17URL(input) {
+  const lower = input.toLowerCase();
+  for (const scheme of Object.keys(LUD17_SCHEMES)) {
+    if (lower.startsWith(scheme)) {
+      const rest = input.substring(scheme.length);
+      const host = rest.split('/')[0];
+      const protocol = host.endsWith('.onion') ? 'http://' : 'https://';
+      return protocol + rest;
+    }
+  }
+  return null;
+}
+
+/**
  * Payment type constants for consistent type checking
  */
 export const PaymentType = {
@@ -86,7 +116,7 @@ export class LightningPaymentService {
    */
   isLNURL(input) {
     const lower = input.toLowerCase();
-    return lower.startsWith('lnurl') || lower.startsWith('lightning:lnurl');
+    return lower.startsWith('lnurl') || lower.startsWith('lightning:lnurl') || lower.startsWith('keyauth://');
   }
 
   /**
@@ -533,15 +563,21 @@ export class LightningPaymentService {
   // ============================================================================
 
   /**
-   * Decodes an LNURL from bech32 format to URL
-   * @param {string} lnurl - The bech32-encoded LNURL
+   * Decodes an LNURL to a URL. Supports both bech32 (LUD-01) and URL schemes (LUD-17).
+   * @param {string} lnurl - The LNURL string (bech32-encoded or LUD-17 scheme)
    * @returns {string} The decoded URL
    * @throws {Error} If decoding fails
    */
   decodeLNURL(lnurl) {
+    const clean = lnurl.trim().replace(/^lightning:/i, '');
+
+    // LUD-17: lnurlp://, lnurlw://, lnurlc://, keyauth://
+    const lud17Url = resolveLUD17URL(clean);
+    if (lud17Url) return lud17Url;
+
+    // LUD-01: bech32-encoded LNURL
     try {
-      const cleanLnurl = lnurl.toLowerCase().trim();
-      const decoded = bech32.decode(cleanLnurl, 2000);
+      const decoded = bech32.decode(clean.toLowerCase(), 2000);
       const bytes = bech32.fromWords(decoded.words);
       return new TextDecoder().decode(new Uint8Array(bytes));
     } catch (error) {


### PR DESCRIPTION
Adds **LUD-17 scheme support** (`lnurlp://`, `lnurlw://`, `lnurlc://`, `keyauth://`) across the wallet while keeping existing **bech32 LNURL flows unchanged**.

**Key changes**

* Introduced `resolveLUD17URL()` helper to convert LUD-17 schemes → `https://` (or `http://` for `.onion`)
* Updated LNURL detection/decoding in wallet UI and modals to try **LUD-17 first, then fallback to bech32**
* `keyauth://` is now recognized as LNURL input
* Updated wallet input parsing to detect LUD-17 schemes

**Compatibility**

* Existing **bech32 LNURL flows remain untouched**
* **Withdraw and pay flows unchanged**, since they already operate on the resolved HTTPS URL.
