### PR TITLE
fix(deps): sync pnpm-lock.yaml axios to 1.15.2 (unblock Netlify)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^1.2.1
         version: 1.6.0
       axios:
-        specifier: 1.13.5
-        version: 1.13.5
+        specifier: 1.15.2
+        version: 1.15.2
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1692,8 +1692,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -3139,8 +3139,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -5776,11 +5777,11 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.13.5:
+  axios@1.15.2:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -7297,7 +7298,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
## Why

Netlify's main deploy is failing with:
\`\`\`
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with <ROOT>/package.json
- axios (lockfile: 1.13.5, manifest: 1.15.2)
\`\`\`

Dependabot PR #120 bumped axios in \`package.json\` + \`package-lock.json\` (npm) but not in \`pnpm-lock.yaml\`. Netlify uses pnpm, so its frozen-lockfile install rejects the mismatch.

## What this changes

Lockfile-only \`pnpm install\` to bring \`pnpm-lock.yaml\` in line with the current \`package.json\`. Diff is 19 lines: axios specifier 1.13.5 → 1.15.2 plus its matching transitive bump proxy-from-env 1.1.0 → 2.1.0. No application code touched.

## Caveat — recurring problem

This unblocks production today. The same failure will recur on every future dependabot PR that touches a direct dep, because dependabot doesn't update \`pnpm-lock.yaml\`. A follow-up structural fix (delete pnpm-lock.yaml since the project is npm-driven, or configure Netlify to use npm explicitly) is recommended.

## Test plan

- [x] \`pnpm install --lockfile-only\` produces a clean diff (only axios + proxy-from-env)
- [ ] Netlify main deploy succeeds after merge