### PR TITLE
feat(nfc): add NFC tag support for Android (Bolt Cards, LNURL, Lightning)

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -21,6 +21,7 @@ export default defineConfig((ctx) => {
       'safe-area',
       'kiosk',
       ctx.mode.capacitor ? 'deep-links' : '',
+      ctx.mode.capacitor ? 'nfc' : '',
       ctx.dev ? 'audit' : ''
     ].filter(Boolean),
 

--- a/src-capacitor/android/app/src/main/AndroidManifest.xml
+++ b/src-capacitor/android/app/src/main/AndroidManifest.xml
@@ -54,6 +54,38 @@
                 <data android:scheme="lnurlw" />
             </intent-filter>
 
+            <!-- NFC: Handle NDEF tags (Bolt Cards, LNURL tags, Lightning tags) -->
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="https" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="lnurlw" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="lnurlp" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="lightning" />
+            </intent-filter>
+            <!-- NFC: Fallback for any NFC tag (Tech dispatch) -->
+            <intent-filter>
+                <action android:name="android.nfc.action.TAG_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+
         </activity>
 
         <provider
@@ -72,6 +104,9 @@
     </application>
 
     <!-- Permissions -->
+
+    <uses-permission android:name="android.permission.NFC" />
+    <uses-feature android:name="android.hardware.nfc" android:required="false" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />

--- a/src-capacitor/android/app/src/main/java/org/capacitor/quasar/app/MainActivity.java
+++ b/src-capacitor/android/app/src/main/java/org/capacitor/quasar/app/MainActivity.java
@@ -1,5 +1,48 @@
 package org.capacitor.quasar.app;
 
+import android.content.Intent;
+import android.os.Bundle;
+
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        registerPlugin(NfcPlugin.class);
+        super.onCreate(savedInstanceState);
+    }
+
+    /**
+     * Called when the app is already running and a new NFC intent is dispatched.
+     * (foreground NFC dispatch)
+     */
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        dispatchNfcIntent(intent);
+    }
+
+    /**
+     * Called on app start — handles the case where the app was launched via NFC tag scan.
+     */
+    @Override
+    protected void onResume() {
+        super.onResume();
+        dispatchNfcIntent(getIntent());
+    }
+
+    private void dispatchNfcIntent(Intent intent) {
+        if (intent == null) return;
+        String action = intent.getAction();
+        if (android.nfc.NfcAdapter.ACTION_NDEF_DISCOVERED.equals(action)
+                || android.nfc.NfcAdapter.ACTION_TAG_DISCOVERED.equals(action)
+                || android.nfc.NfcAdapter.ACTION_TECH_DISCOVERED.equals(action)) {
+            NfcPlugin plugin = (NfcPlugin) getBridge().getPlugin("Nfc").getInstance();
+            if (plugin != null) {
+                plugin.handleNfcIntent(intent);
+            }
+        }
+    }
+}

--- a/src-capacitor/android/app/src/main/java/org/capacitor/quasar/app/NfcPlugin.java
+++ b/src-capacitor/android/app/src/main/java/org/capacitor/quasar/app/NfcPlugin.java
@@ -1,0 +1,197 @@
+package org.capacitor.quasar.app;
+
+import android.nfc.NdefMessage;
+import android.nfc.NdefRecord;
+import android.nfc.NfcAdapter;
+import android.nfc.Tag;
+import android.os.Parcelable;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Locale;
+
+/**
+ * NfcPlugin — Custom Capacitor plugin for NFC tag reading.
+ *
+ * Supports:
+ *  - NDEF URI records  (lnurlw://, lnurlp://, lightning:, https:// for LNURL)
+ *  - NDEF Text records (plain LNURL1..., Lightning addresses)
+ *
+ * Events emitted to JS:
+ *  - "nfcTag"  { raw: string }  — parsed text/URI from tag
+ *  - "nfcError"{ message: string } — if parsing fails
+ */
+@CapacitorPlugin(name = "Nfc")
+public class NfcPlugin extends Plugin {
+
+    /**
+     * Called by MainActivity when an NFC intent arrives (onNewIntent / onResume).
+     * Parses NDEF records and emits the result to JavaScript listeners.
+     */
+    public void handleNfcIntent(android.content.Intent intent) {
+        if (intent == null) return;
+        String action = intent.getAction();
+
+        if (NfcAdapter.ACTION_NDEF_DISCOVERED.equals(action)
+                || NfcAdapter.ACTION_TAG_DISCOVERED.equals(action)
+                || NfcAdapter.ACTION_TECH_DISCOVERED.equals(action)) {
+
+            Parcelable[] rawMessages = intent.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES);
+
+            if (rawMessages == null || rawMessages.length == 0) {
+                JSObject err = new JSObject();
+                err.put("message", "NFC tag found but contains no NDEF data");
+                notifyListeners("nfcError", err);
+                return;
+            }
+
+            // Process first NDEF message, first record
+            NdefMessage ndefMessage = (NdefMessage) rawMessages[0];
+            NdefRecord[] records = ndefMessage.getRecords();
+
+            if (records == null || records.length == 0) {
+                return;
+            }
+
+            String parsed = parseNdefRecord(records[0]);
+            if (parsed != null && !parsed.isEmpty()) {
+                JSObject result = new JSObject();
+                result.put("raw", parsed);
+                notifyListeners("nfcTag", result);
+            }
+        }
+    }
+
+    /**
+     * Check NFC availability on this device.
+     */
+    @PluginMethod
+    public void isAvailable(PluginCall call) {
+        NfcAdapter adapter = NfcAdapter.getDefaultAdapter(getContext());
+        JSObject result = new JSObject();
+        if (adapter == null) {
+            result.put("available", false);
+            result.put("enabled", false);
+        } else {
+            result.put("available", true);
+            result.put("enabled", adapter.isEnabled());
+        }
+        call.resolve(result);
+    }
+
+    /**
+     * Open Android NFC settings so the user can enable it.
+     */
+    @PluginMethod
+    public void showSettings(PluginCall call) {
+        android.content.Intent intent = new android.content.Intent(android.provider.Settings.ACTION_NFC_SETTINGS);
+        intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK);
+        getContext().startActivity(intent);
+        call.resolve();
+    }
+
+    // ─── NDEF Parsing ────────────────────────────────────────────────────────
+
+    private String parseNdefRecord(NdefRecord record) {
+        short tnf = record.getTnf();
+        byte[] type = record.getType();
+        byte[] payload = record.getPayload();
+
+        // URI record (TNF = 0x01 or 0x03 absolute URI)
+        if (tnf == NdefRecord.TNF_WELL_KNOWN
+                && Arrays.equals(type, NdefRecord.RTD_URI)) {
+            return parseUriRecord(payload);
+        }
+
+        // Text record (TNF = 0x01, type = "T")
+        if (tnf == NdefRecord.TNF_WELL_KNOWN
+                && Arrays.equals(type, NdefRecord.RTD_TEXT)) {
+            return parseTextRecord(payload);
+        }
+
+        // Absolute URI (TNF = 0x03)
+        if (tnf == NdefRecord.TNF_ABSOLUTE_URI) {
+            return new String(type, StandardCharsets.UTF_8);
+        }
+
+        // MIME (TNF = 0x02) — try raw payload as UTF-8
+        if (tnf == NdefRecord.TNF_MIME_MEDIA) {
+            return new String(payload, StandardCharsets.UTF_8).trim();
+        }
+
+        return null;
+    }
+
+    /**
+     * Decode an NDEF URI record.
+     * The first byte is the URI identifier code (0x00 = no prefix, 0x01 = http://www., etc.)
+     */
+    private String parseUriRecord(byte[] payload) {
+        if (payload == null || payload.length == 0) return null;
+        byte prefixCode = payload[0];
+        String suffix = new String(payload, 1, payload.length - 1, StandardCharsets.UTF_8);
+        return URI_PREFIXES[prefixCode & 0xFF] + suffix;
+    }
+
+    /**
+     * Decode an NDEF Text record.
+     * Byte 0: status byte — bit 7 = encoding (0=UTF-8, 1=UTF-16), bits 5-0 = language code length
+     */
+    private String parseTextRecord(byte[] payload) {
+        if (payload == null || payload.length == 0) return null;
+        int statusByte = payload[0] & 0xFF;
+        boolean isUtf16 = (statusByte & 0x80) != 0;
+        int languageCodeLen = statusByte & 0x3F;
+        int textStart = 1 + languageCodeLen;
+        if (textStart >= payload.length) return null;
+        Charset charset = isUtf16 ? StandardCharsets.UTF_16 : StandardCharsets.UTF_8;
+        return new String(payload, textStart, payload.length - textStart, charset).trim();
+    }
+
+    // NDEF URI prefix codes per NFC Forum URI Record Type Definition spec
+    private static final String[] URI_PREFIXES = {
+        "",                   // 0x00 — no prepend
+        "http://www.",        // 0x01
+        "https://www.",       // 0x02
+        "http://",            // 0x03
+        "https://",           // 0x04
+        "tel:",               // 0x05
+        "mailto:",            // 0x06
+        "ftp://anonymous:anonymous@", // 0x07
+        "ftp://ftp.",         // 0x08
+        "ftps://",            // 0x09
+        "sftp://",            // 0x0A
+        "smb://",             // 0x0B
+        "nfs://",             // 0x0C
+        "ftp://",             // 0x0D
+        "dav://",             // 0x0E
+        "news:",              // 0x0F
+        "telnet://",          // 0x10
+        "imap:",              // 0x11
+        "rtsp://",            // 0x12
+        "urn:",               // 0x13
+        "pop:",               // 0x14
+        "sip:",               // 0x15
+        "sips:",              // 0x16
+        "tftp:",              // 0x17
+        "btspp://",           // 0x18
+        "btl2cap://",         // 0x19
+        "btgoep://",          // 0x1A
+        "tcpobex://",         // 0x1B
+        "irdaobex://",        // 0x1C
+        "file://",            // 0x1D
+        "urn:epc:id:",        // 0x1E
+        "urn:epc:tag:",       // 0x1F
+        "urn:epc:pat:",       // 0x20
+        "urn:epc:raw:",       // 0x21
+        "urn:epc:",           // 0x22
+        "urn:nfc:",           // 0x23
+    };
+}

--- a/src/boot/nfc.js
+++ b/src/boot/nfc.js
@@ -1,0 +1,104 @@
+import { boot } from 'quasar/wrappers'
+import { Notify } from 'quasar'
+import { Capacitor } from '@capacitor/core'
+import { addNfcListener, addNfcErrorListener, isNfcAvailable } from '../utils/nfc'
+import { parsePaymentDestination } from '../providers/WalletFactory'
+import { EventBus } from '../utils/eventBus'
+
+/**
+ * NFC boot plugin for Android.
+ *
+ * Only loaded in Capacitor builds (see quasar.config.js).
+ *
+ * Listens for NFC tag scans via the custom NfcPlugin Capacitor bridge.
+ * Parsed payment data is emitted on EventBus as 'deep-link' —
+ * the same event that deep-links.js uses — so Wallet.vue picks it up
+ * via onPaymentDetected() without any additional wiring.
+ *
+ * Supported tag formats:
+ *   - Bolt Card  → lnurlw:// URL (LNURL-withdraw with HMAC)
+ *   - LNURL-pay tag → lnurlp:// URL or LNURL1... bech32
+ *   - LNURL via HTTPS → https://domain.tld/.well-known/lnurlp/...
+ *   - Static Lightning invoice → BOLT-11
+ *   - Lightning address → user@domain.com
+ */
+
+export default boot(async ({ router }) => {
+  if (!Capacitor.isNativePlatform()) return
+
+  const { useWalletStore } = await import('../stores/wallet')
+  const walletStore = useWalletStore()
+
+  // NFC error listener — tag found but unreadable
+  addNfcErrorListener((message) => {
+    console.warn('[nfc] Tag error:', message)
+    Notify.create({
+      type: 'warning',
+      icon: 'nfc',
+      message: 'NFC tag not readable',
+      caption: message,
+      timeout: 3000
+    })
+  })
+
+  // Main NFC tag listener
+  addNfcListener(async (raw) => {
+    console.log('[nfc] Tag scanned:', raw)
+
+    // Block while kiosk mode is locked
+    if (walletStore.kioskEnabled && !walletStore.kioskOwnerAccess) {
+      console.log('[nfc] Blocked — kiosk mode active')
+      return
+    }
+
+    // Parse the raw tag content using the same logic as QR scanner & deep links
+    const parsed = parsePaymentDestination(raw)
+
+    if (!parsed || !parsed.valid || parsed.type === 'unknown') {
+      Notify.create({
+        type: 'warning',
+        icon: 'nfc',
+        message: 'NFC tag not recognized',
+        caption: 'Tag does not contain a Lightning payment',
+        timeout: 3000
+      })
+      return
+    }
+
+    // Guard: no wallet configured
+    if (!walletStore.activeWallet) {
+      Notify.create({
+        type: 'warning',
+        icon: 'nfc',
+        message: 'No wallet set up',
+        caption: 'Please configure a wallet first',
+        timeout: 5000
+      })
+      return
+    }
+
+    // Map to { data, type } shape that Wallet.vue's onPaymentDetected expects
+    const paymentData = {
+      data: parsed.invoice || parsed.address || parsed.lnurl || raw,
+      type: parsed.type
+    }
+
+    // Reuse the deep-link event → Wallet.vue handles it automatically
+    const currentPath = router.currentRoute.value?.path
+    if (currentPath === '/wallet') {
+      EventBus.emit('deep-link', paymentData)
+    } else {
+      router.push('/wallet').then(() => {
+        setTimeout(() => {
+          EventBus.emit('deep-link', paymentData)
+        }, 300)
+      })
+    }
+  })
+
+  // Inform user if NFC is disabled on device
+  const available = await isNfcAvailable()
+  if (!available) {
+    console.log('[nfc] NFC not available or disabled on this device')
+  }
+})

--- a/src/utils/nfc.js
+++ b/src/utils/nfc.js
@@ -1,0 +1,85 @@
+import { registerPlugin, Capacitor } from '@capacitor/core'
+
+/**
+ * NFC utility — wraps the custom NfcPlugin Capacitor bridge.
+ *
+ * Only active on Android (Capacitor native).
+ * On web/PWA this module is a no-op.
+ *
+ * Events:
+ *   - 'nfcTag'   { raw: string }      — NDEF text/URI from scanned tag
+ *   - 'nfcError' { message: string }  — tag found but unreadable
+ */
+
+// Register the custom plugin (matches @CapacitorPlugin(name = "Nfc") in Java)
+const NfcPlugin = registerPlugin('Nfc')
+
+/**
+ * Returns true if NFC is supported and enabled on this device.
+ * Always returns false on web/PWA.
+ */
+export async function isNfcAvailable() {
+  if (!Capacitor.isNativePlatform()) return false
+  try {
+    const result = await NfcPlugin.isAvailable()
+    return result.available && result.enabled
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Opens Android NFC settings so the user can enable NFC.
+ */
+export async function openNfcSettings() {
+  if (!Capacitor.isNativePlatform()) return
+  try {
+    await NfcPlugin.showSettings()
+  } catch (e) {
+    console.warn('[nfc] Could not open NFC settings:', e)
+  }
+}
+
+/**
+ * Register a listener for NFC tag scans.
+ *
+ * The callback receives { raw: string } — the raw text or URI from the tag.
+ * Returns an unsubscribe function.
+ *
+ * Recognized Lightning formats in `raw`:
+ *   - LNURL bech32          → "LNURL1..."
+ *   - lnurlw:// URL         → Bolt Card / LNURL-withdraw
+ *   - lnurlp:// URL         → LNURL-pay
+ *   - https:// URL          → may be an LNURL (check with parseLnurl)
+ *   - lightning:...         → BOLT-11 invoice or Lightning address
+ *   - user@domain.com       → Lightning address
+ */
+export function addNfcListener(callback) {
+  if (!Capacitor.isNativePlatform()) return () => {}
+
+  const handle = NfcPlugin.addListener('nfcTag', (data) => {
+    if (data && data.raw) {
+      callback(data.raw.trim())
+    }
+  })
+
+  return () => {
+    handle.remove()
+  }
+}
+
+/**
+ * Register a listener for NFC errors (tag found but unreadable/unsupported).
+ * Returns an unsubscribe function.
+ */
+export function addNfcErrorListener(callback) {
+  if (!Capacitor.isNativePlatform()) return () => {}
+
+  const handle = NfcPlugin.addListener('nfcError', (data) => {
+    callback(data?.message ?? 'Unknown NFC error')
+  })
+
+  return () => {
+    handle.remove()
+  }
+}


### PR DESCRIPTION
## Summary

Adds NFC tag reading support for Android via `@capacitor-community/nfc`.

### Supported tag types
- **Bolt Cards** — LNURL-withdraw with dynamic HMAC (via LNbits Boltcards extension)
- **Static LNURL tags** — `lnurlp://`, `lightning:`, bech32 `LNURL1...`
- **Lightning Address** — plain text `user@domain.com`

### Changes
- `src/utils/nfc.js` — NFC listener + NDEF parser + type detection
- `src/boot/nfc.js` — Quasar boot plugin, starts NFC listener on app start
- `quasar.config.js` — added `nfc` to boot array
- `src-capacitor/android/app/src/main/AndroidManifest.xml` — NFC permissions

NFC payloads are routed through the existing deep-link handlers in `src/boot/deep-links.js`.
