### PR TITLE
Fix: Android shows an app chooser dialog instead of routing the inten…

### DIFF
--- a/src-capacitor/android/app/src/main/java/org/capacitor/quasar/app/MainActivity.java
+++ b/src-capacitor/android/app/src/main/java/org/capacitor/quasar/app/MainActivity.java
@@ -38,11 +38,10 @@ public class MainActivity extends BridgeActivity {
             flags
         );
 
-        // Mirror the manifest's NFC intent-filters so foreground dispatch
-        // catches every action dispatchNfcIntent() knows how to route.
-        // Without TAG_DISCOVERED and TECH_DISCOVERED the system would fall
-        // back to the manifest for non-NDEF tags and the chooser could
-        // reappear.
+        // Cover every action dispatchNfcIntent() routes. Without
+        // TAG_DISCOVERED and TECH_DISCOVERED in the filter, non-NDEF
+        // tags fall back to the manifest path where the chooser can
+        // reappear if another wallet declares the same filters.
         try {
             IntentFilter ndef = new IntentFilter(NfcAdapter.ACTION_NDEF_DISCOVERED);
             ndef.addDataType("*/*");
@@ -52,9 +51,9 @@ public class MainActivity extends BridgeActivity {
         } catch (IntentFilter.MalformedMimeTypeException e) {
             // "*/*" is well-formed so this branch is unreachable in
             // practice. If it ever fired we'd rather disable foreground
-            // dispatch entirely than register a null filter array, which
-            // would silently widen registration to every NDEF tag the
-            // device sees.
+            // dispatch entirely than register a null filter array,
+            // which would silently intercept every tag the device
+            // sees while the activity is in the foreground.
             nfcAdapter = null;
         }
     }
@@ -85,9 +84,11 @@ public class MainActivity extends BridgeActivity {
     }
 
     /**
-     * Receive tag intents delivered while the activity is already
-     * running. setIntent() caches the intent so onResume sees the
-     * same value on the next lifecycle pass.
+     * Receive tag and deep-link intents delivered while the activity
+     * is already running. setIntent() keeps getIntent() in sync with
+     * the most recent delivery so Capacitor and any later readers see
+     * the same value; dispatchNfcIntent() then routes NFC actions and
+     * consumes the intent so onResume cannot replay them.
      */
     @Override
     protected void onNewIntent(Intent intent) {

--- a/src-capacitor/android/app/src/main/java/org/capacitor/quasar/app/MainActivity.java
+++ b/src-capacitor/android/app/src/main/java/org/capacitor/quasar/app/MainActivity.java
@@ -15,6 +15,12 @@ public class MainActivity extends BridgeActivity {
     private PendingIntent nfcPendingIntent;
     private IntentFilter[] nfcIntentFilters;
 
+    /**
+     * Register Capacitor plugins and prepare foreground NFC dispatch.
+     * Foreground dispatch lets this activity claim exclusive tag
+     * priority over any other installed wallet while it is in the
+     * foreground, bypassing the Android app chooser entirely.
+     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         registerPlugin(NfcPlugin.class);
@@ -32,15 +38,31 @@ public class MainActivity extends BridgeActivity {
             flags
         );
 
+        // Mirror the manifest's NFC intent-filters so foreground dispatch
+        // catches every action dispatchNfcIntent() knows how to route.
+        // Without TAG_DISCOVERED and TECH_DISCOVERED the system would fall
+        // back to the manifest for non-NDEF tags and the chooser could
+        // reappear.
         try {
             IntentFilter ndef = new IntentFilter(NfcAdapter.ACTION_NDEF_DISCOVERED);
             ndef.addDataType("*/*");
-            nfcIntentFilters = new IntentFilter[]{ ndef };
+            IntentFilter tag = new IntentFilter(NfcAdapter.ACTION_TAG_DISCOVERED);
+            IntentFilter tech = new IntentFilter(NfcAdapter.ACTION_TECH_DISCOVERED);
+            nfcIntentFilters = new IntentFilter[]{ ndef, tag, tech };
         } catch (IntentFilter.MalformedMimeTypeException e) {
-            nfcIntentFilters = null;
+            // "*/*" is well-formed so this branch is unreachable in
+            // practice. If it ever fired we'd rather disable foreground
+            // dispatch entirely than register a null filter array, which
+            // would silently widen registration to every NDEF tag the
+            // device sees.
+            nfcAdapter = null;
         }
     }
 
+    /**
+     * Re-enable foreground dispatch and process any tag intent the
+     * activity was launched with (cold start via tag scan).
+     */
     @Override
     protected void onResume() {
         super.onResume();
@@ -50,6 +72,10 @@ public class MainActivity extends BridgeActivity {
         dispatchNfcIntent(getIntent());
     }
 
+    /**
+     * Release foreground dispatch so the rest of the system regains
+     * its normal NFC routing while the activity is not visible.
+     */
     @Override
     protected void onPause() {
         super.onPause();
@@ -58,6 +84,11 @@ public class MainActivity extends BridgeActivity {
         }
     }
 
+    /**
+     * Receive tag intents delivered while the activity is already
+     * running. setIntent() caches the intent so onResume sees the
+     * same value on the next lifecycle pass.
+     */
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
@@ -75,6 +106,10 @@ public class MainActivity extends BridgeActivity {
             if (plugin != null) {
                 plugin.handleNfcIntent(intent);
             }
+            // Consume the intent so a subsequent onResume cycle cannot
+            // re-dispatch the same tag (e.g. user backgrounds and
+            // returns after a Boltcard scan would otherwise replay it).
+            setIntent(new Intent());
         }
     }
 }

--- a/src-capacitor/android/app/src/main/java/org/capacitor/quasar/app/MainActivity.java
+++ b/src-capacitor/android/app/src/main/java/org/capacitor/quasar/app/MainActivity.java
@@ -1,22 +1,63 @@
 package org.capacitor.quasar.app;
 
+import android.app.PendingIntent;
 import android.content.Intent;
+import android.content.IntentFilter;
+import android.nfc.NfcAdapter;
+import android.os.Build;
 import android.os.Bundle;
 
 import com.getcapacitor.BridgeActivity;
 
 public class MainActivity extends BridgeActivity {
 
+    private NfcAdapter nfcAdapter;
+    private PendingIntent nfcPendingIntent;
+    private IntentFilter[] nfcIntentFilters;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         registerPlugin(NfcPlugin.class);
         super.onCreate(savedInstanceState);
+
+        nfcAdapter = NfcAdapter.getDefaultAdapter(this);
+        if (nfcAdapter == null) return;
+
+        int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+            ? PendingIntent.FLAG_MUTABLE : 0;
+
+        nfcPendingIntent = PendingIntent.getActivity(
+            this, 0,
+            new Intent(this, getClass()).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
+            flags
+        );
+
+        try {
+            IntentFilter ndef = new IntentFilter(NfcAdapter.ACTION_NDEF_DISCOVERED);
+            ndef.addDataType("*/*");
+            nfcIntentFilters = new IntentFilter[]{ ndef };
+        } catch (IntentFilter.MalformedMimeTypeException e) {
+            nfcIntentFilters = null;
+        }
     }
 
-    /**
-     * Called when the app is already running and a new NFC intent is dispatched.
-     * (foreground NFC dispatch)
-     */
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (nfcAdapter != null && nfcAdapter.isEnabled()) {
+            nfcAdapter.enableForegroundDispatch(this, nfcPendingIntent, nfcIntentFilters, null);
+        }
+        dispatchNfcIntent(getIntent());
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        if (nfcAdapter != null) {
+            nfcAdapter.disableForegroundDispatch(this);
+        }
+    }
+
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
@@ -24,21 +65,12 @@ public class MainActivity extends BridgeActivity {
         dispatchNfcIntent(intent);
     }
 
-    /**
-     * Called on app start — handles the case where the app was launched via NFC tag scan.
-     */
-    @Override
-    public void onResume() {
-        super.onResume();
-        dispatchNfcIntent(getIntent());
-    }
-
     private void dispatchNfcIntent(Intent intent) {
         if (intent == null) return;
         String action = intent.getAction();
-        if (android.nfc.NfcAdapter.ACTION_NDEF_DISCOVERED.equals(action)
-                || android.nfc.NfcAdapter.ACTION_TAG_DISCOVERED.equals(action)
-                || android.nfc.NfcAdapter.ACTION_TECH_DISCOVERED.equals(action)) {
+        if (NfcAdapter.ACTION_NDEF_DISCOVERED.equals(action)
+            || NfcAdapter.ACTION_TAG_DISCOVERED.equals(action)
+            || NfcAdapter.ACTION_TECH_DISCOVERED.equals(action)) {
             NfcPlugin plugin = (NfcPlugin) getBridge().getPlugin("Nfc").getInstance();
             if (plugin != null) {
                 plugin.handleNfcIntent(intent);


### PR DESCRIPTION
…t directly to the app

## Problem

When BuhoGO is open in the foreground and an NFC tag is scanned, Android shows an app chooser dialog instead of routing the intent directly to the app.

This happens because the current implementation relies solely on manifest intent-filters, which Android uses as a fallback when no app has claimed foreground priority. If any other installed wallet also registers the same schemes (lnurlw://, lightning:, etc.), the chooser appears.

## Fix

Enable Android's foreground dispatch system in MainActivity. This gives BuhoGO exclusive NFC priority while it is in the foreground, bypassing the chooser entirely — regardless of what other apps are installed.

- `onCreate`: initialize NfcAdapter, PendingIntent and IntentFilter once
- `onResume`: enable foreground dispatch
- `onPause`: disable foreground dispatch (required by Android API)

The manifest intent-filters remain in place as fallback for cold-start tag launches (app not yet running).