### PR TITLE
feat(nfc): add Bolt Card (NTAG 424 DNA) support

### DIFF
--- a/src-capacitor/android/app/src/main/AndroidManifest.xml
+++ b/src-capacitor/android/app/src/main/AndroidManifest.xml
@@ -80,6 +80,16 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="lightning" />
             </intent-filter>
+            <!-- NFC: IsoDep tech dispatch — catches NTAG 424 DNA / Bolt Cards when
+                 Android does not fire NDEF_DISCOVERED for T4T tags -->
+            <intent-filter>
+                <action android:name="android.nfc.action.TECH_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <meta-data
+                android:name="android.nfc.action.TECH_DISCOVERED"
+                android:resource="@xml/nfc_tech_filter" />
+
             <!-- NFC: Fallback for any NFC tag (Tech dispatch) -->
             <intent-filter>
                 <action android:name="android.nfc.action.TAG_DISCOVERED" />

--- a/src-capacitor/android/app/src/main/java/org/capacitor/quasar/app/NfcPlugin.java
+++ b/src-capacitor/android/app/src/main/java/org/capacitor/quasar/app/NfcPlugin.java
@@ -1,9 +1,12 @@
 package org.capacitor.quasar.app;
 
+import android.nfc.FormatException;
 import android.nfc.NdefMessage;
 import android.nfc.NdefRecord;
 import android.nfc.NfcAdapter;
 import android.nfc.Tag;
+import android.nfc.tech.IsoDep;
+import android.nfc.tech.Ndef;
 import android.os.Parcelable;
 
 import com.getcapacitor.JSObject;
@@ -46,9 +49,20 @@ public class NfcPlugin extends Plugin {
             Parcelable[] rawMessages = intent.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES);
 
             if (rawMessages == null || rawMessages.length == 0) {
-                JSObject err = new JSObject();
-                err.put("message", "NFC tag found but contains no NDEF data");
-                notifyListeners("nfcError", err);
+                // NTAG 424 DNA (Bolt Card) is an ISO-DEP / T4T tag. Android does not always
+                // deliver EXTRA_NDEF_MESSAGES for these tags — fall back to reading the NDEF
+                // file directly via the Ndef or IsoDep technology classes.
+                Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
+                String fallback = tryReadNdefFromTag(tag);
+                if (fallback != null && !fallback.isEmpty()) {
+                    JSObject result = new JSObject();
+                    result.put("raw", fallback);
+                    notifyListeners("nfcTag", result);
+                } else {
+                    JSObject err = new JSObject();
+                    err.put("message", "NFC tag found but contains no NDEF data");
+                    notifyListeners("nfcError", err);
+                }
                 return;
             }
 
@@ -153,6 +167,129 @@ public class NfcPlugin extends Plugin {
         if (textStart >= payload.length) return null;
         Charset charset = isUtf16 ? StandardCharsets.UTF_16 : StandardCharsets.UTF_8;
         return new String(payload, textStart, payload.length - textStart, charset).trim();
+    }
+
+    // ─── Bolt Card / NTAG 424 DNA fallback reading ───────────────────────────
+
+    /**
+     * Called when Android did not deliver EXTRA_NDEF_MESSAGES (e.g. NTAG 424 DNA /
+     * Bolt Cards dispatched via TAG_DISCOVERED or TECH_DISCOVERED).
+     *
+     * Tries two approaches in order:
+     *  1. Android Ndef technology class  — works when the tag supports T4T NDEF
+     *     and the NFC stack can negotiate it at runtime.
+     *  2. Raw IsoDep APDU sequence       — T4T NDEF read per ISO 7816-4 / NFC
+     *     Forum T4T spec; required when Ndef.get() returns null (some Android
+     *     versions / OEM NFC stacks fail to surface NTAG 424 DNA as Ndef).
+     */
+    private String tryReadNdefFromTag(Tag tag) {
+        if (tag == null) return null;
+
+        // Approach 1: standard Ndef technology
+        Ndef ndef = Ndef.get(tag);
+        if (ndef != null) {
+            try {
+                ndef.connect();
+                NdefMessage message = ndef.getNdefMessage();
+                if (message != null) {
+                    NdefRecord[] records = message.getRecords();
+                    if (records != null && records.length > 0) {
+                        return parseNdefRecord(records[0]);
+                    }
+                }
+            } catch (Exception ignored) {
+                // fall through to IsoDep
+            } finally {
+                try { ndef.close(); } catch (Exception ignored) {}
+            }
+        }
+
+        // Approach 2: raw T4T NDEF over IsoDep (NTAG 424 DNA / Bolt Card path)
+        return tryReadNdefViaIsoDep(tag);
+    }
+
+    /**
+     * Reads the NDEF file from a T4T tag using raw ISO 7816-4 APDU commands.
+     *
+     * Sequence:
+     *   SELECT NDEF Application → SELECT CC File → READ CC →
+     *   SELECT NDEF File (ID from CC) → READ NDEF length → READ NDEF data
+     */
+    private String tryReadNdefViaIsoDep(Tag tag) {
+        IsoDep isoDep = IsoDep.get(tag);
+        if (isoDep == null) return null;
+
+        try {
+            isoDep.connect();
+            isoDep.setTimeout(3000);
+
+            // SELECT NDEF Application (D2 76 00 00 85 01 01)
+            byte[] r = isoDep.transceive(new byte[]{
+                0x00, (byte)0xA4, 0x04, 0x00, 0x07,
+                (byte)0xD2, 0x76, 0x00, 0x00, (byte)0x85, 0x01, 0x01, 0x00
+            });
+            if (!swOk(r)) return null;
+
+            // SELECT Capability Container (E1 03)
+            r = isoDep.transceive(new byte[]{
+                0x00, (byte)0xA4, 0x00, 0x0C, 0x02, (byte)0xE1, 0x03
+            });
+            if (!swOk(r)) return null;
+
+            // READ BINARY — first 15 bytes of CC
+            r = isoDep.transceive(new byte[]{0x00, (byte)0xB0, 0x00, 0x00, 0x0F});
+            if (!swOk(r) || r.length < 17) return null;
+
+            // CC[9..10] = NDEF file ID (typically E1 04)
+            byte fileId0 = r[9];
+            byte fileId1 = r[10];
+
+            // SELECT NDEF File
+            r = isoDep.transceive(new byte[]{
+                0x00, (byte)0xA4, 0x00, 0x0C, 0x02, fileId0, fileId1
+            });
+            if (!swOk(r)) return null;
+
+            // READ BINARY — 2-byte NDEF length field at offset 0
+            r = isoDep.transceive(new byte[]{0x00, (byte)0xB0, 0x00, 0x00, 0x02});
+            if (!swOk(r) || r.length < 4) return null;
+            int ndefLen = ((r[0] & 0xFF) << 8) | (r[1] & 0xFF);
+            if (ndefLen <= 0 || ndefLen > 2000) return null;
+
+            // READ NDEF data in chunks of up to 250 bytes (offset starts at 2)
+            byte[] ndefBytes = new byte[ndefLen];
+            int pos = 0;
+            while (pos < ndefLen) {
+                int chunk = Math.min(ndefLen - pos, 250);
+                int fileOff = pos + 2;
+                r = isoDep.transceive(new byte[]{
+                    0x00, (byte)0xB0,
+                    (byte)((fileOff >> 8) & 0xFF),
+                    (byte)(fileOff & 0xFF),
+                    (byte)chunk
+                });
+                if (!swOk(r) || r.length < chunk + 2) return null;
+                System.arraycopy(r, 0, ndefBytes, pos, chunk);
+                pos += chunk;
+            }
+
+            // Parse using Android's NdefMessage (handles all TNF/type variants)
+            NdefMessage message = new NdefMessage(ndefBytes);
+            NdefRecord[] records = message.getRecords();
+            if (records == null || records.length == 0) return null;
+            return parseNdefRecord(records[0]);
+
+        } catch (Exception ignored) {
+            return null;
+        } finally {
+            try { isoDep.close(); } catch (Exception ignored) {}
+        }
+    }
+
+    private boolean swOk(byte[] r) {
+        return r != null && r.length >= 2
+            && r[r.length - 2] == (byte)0x90
+            && r[r.length - 1] == (byte)0x00;
     }
 
     // NDEF URI prefix codes per NFC Forum URI Record Type Definition spec

--- a/src-capacitor/android/app/src/main/res/xml/nfc_tech_filter.xml
+++ b/src-capacitor/android/app/src/main/res/xml/nfc_tech_filter.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- NTAG 424 DNA / Bolt Card (T4T / ISO-DEP) -->
+    <tech-list>
+        <tech>android.nfc.tech.IsoDep</tech>
+    </tech-list>
+    <!-- Standard NDEF tags (NTAG 21x, etc.) -->
+    <tech-list>
+        <tech>android.nfc.tech.Ndef</tech>
+    </tech-list>
+    <!-- NfcA fallback (covers MiFare Ultralight / NTAG 21x without NDEF layer) -->
+    <tech-list>
+        <tech>android.nfc.tech.NfcA</tech>
+    </tech-list>
+</resources>

--- a/src/boot/nfc.js
+++ b/src/boot/nfc.js
@@ -53,6 +53,15 @@ export default boot(async ({ router }) => {
     // Parse the raw tag content using the same logic as QR scanner & deep links
     const parsed = parsePaymentDestination(raw)
 
+    // Bolt Cards often encode a plain https:// URL that resolves to a
+    // LNURL-withdraw response. parsePaymentDestination() can't know this
+    // without a network round-trip, so we forward https:// NFC tags as
+    // type 'lnurl' — Wallet.vue's fetchLNURLInfo() will fetch and verify.
+    if ((!parsed || !parsed.valid || parsed.type === 'unknown')
+        && /^https?:\/\//i.test(raw)) {
+      parsed = { type: 'lnurl', lnurl: raw, valid: true }
+    }
+
     if (!parsed || !parsed.valid || parsed.type === 'unknown') {
       Notify.create({
         type: 'warning',

--- a/src/pages/Wallet.vue
+++ b/src/pages/Wallet.vue
@@ -3997,6 +3997,9 @@ export default {
     decodeLNURL(lnurl) {
       const clean = lnurl.trim().replace(/^lightning:/i, '');
 
+      // Plain https:// or http:// URL (e.g. Bolt Card NFC URL — already decoded)
+      if (/^https?:\/\//i.test(clean)) return clean;
+
       // LUD-17: lnurlp://, lnurlw://, lnurlc://, keyauth://
       const lud17Url = resolveLUD17URL(clean);
       if (lud17Url) return lud17Url;


### PR DESCRIPTION
## Summary

Adds reliable Bolt Card (NTAG 424 DNA) support to the existing NFC
infrastructure. Bolt Cards already worked in the happy path (when Android
delivers EXTRA_NDEF_MESSAGES), but failed silently on many devices and
Android versions due to how NTAG 424 DNA tags are dispatched.

### Root cause

NTAG 424 DNA is an ISO-DEP / T4T tag. Android does not always fire
`ACTION_NDEF_DISCOVERED` with NDEF data attached for these tags — it
sometimes dispatches `ACTION_TAG_DISCOVERED` or `ACTION_TECH_DISCOVERED`
instead with no `EXTRA_NDEF_MESSAGES`. The previous `NfcPlugin.java`
emitted an `nfcError` in this case, making Bolt Cards unreliable.

### What was added

**`NfcPlugin.java`** — IsoDep APDU fallback

When `EXTRA_NDEF_MESSAGES` is empty, the plugin now reads the NDEF file
directly from the tag:
1. First tries Android's `Ndef` technology class (zero-overhead, works
   on most modern Android versions)
2. Falls back to a raw T4T APDU sequence over `IsoDep`:
   `SELECT NDEF Application → SELECT CC → READ CC → SELECT NDEF File
   → READ NDEF length → READ NDEF data`

The raw bytes are parsed with Android's `NdefMessage` constructor and
handed to the existing `parseNdefRecord()` — no duplicate parsing logic.

**`AndroidManifest.xml` + `nfc_tech_filter.xml`** (new file)

Added `TECH_DISCOVERED` intent filter with an explicit tech list
(IsoDep, Ndef, NfcA). This gives our Activity higher dispatch priority
than the generic `TAG_DISCOVERED` fallback when an NTAG 424 DNA is
presented.

**`src/boot/nfc.js`** — https:// Bolt Card URL handling

Bolt Cards frequently store a plain `https://` URL in their NDEF file
(NDEF URI prefix byte `0x04`), not `lnurlw://`. This is the most common
real-world Bolt Card configuration. `parsePaymentDestination()` correctly
returns `type: 'unknown'` for these because it cannot know without a
network call whether an https URL is an LNURL server.

NFC-received `https://` URLs are now forwarded as `type: 'lnurl'` so
`Wallet.vue`'s `fetchLNURLInfo()` resolves them against the LNURL server
and checks for `tag: "withdrawRequest"`.

**`src/pages/Wallet.vue`** — `decodeLNURL()` passthrough

Plain `https://` inputs are returned as-is instead of entering the
bech32 decoder (which throws `Invalid LNURL`). Required for the https://
Bolt Card path to reach `fetchLNURLInfo()` successfully.

### What is NOT changed

- NTAG 21x / standard NDEF tags: fast path through `EXTRA_NDEF_MESSAGES`
  is completely unchanged.
- SUN / CMAC verification (the `p=` and `c=` parameters in the Bolt Card
  URL): this is handled entirely server-side. No cryptography in the app.
- The LNURL-withdraw flow in `Wallet.vue` including k1 callback was
  already complete — no changes needed there.

### Reference

Validated approach against [Electrum PR #10575](https://github.com/spesmilo/electrum/pull/10575)
(merged), which confirms the `lnurlw://` → `https://` routing pattern.
Our implementation additionally covers the direct `https://` URL case
(most common Bolt Card format) and the IsoDep APDU fallback for
devices that don't surface NTAG 424 DNA via `NDEF_DISCOVERED`.

## Test plan

- [ ] Bolt Card (`lnurlw://` NDEF) tap → Withdraw Sheet appears
- [ ] Bolt Card (`https://` NDEF) tap → Withdraw Sheet appears
- [ ] NTAG 21x (LNURL-pay) tap → regression: still works correctly
- [ ] Bolt Card tapped twice → k1 already used error shown correctly
- [ ] NFC disabled on device → no crash, settings prompt shown
- [ ] Kiosk mode locked → NFC tap is blocked
