### PR TITLE
feat(bolt-card): LUD-XX pinLimit — PIN authorization for LNURL-withdraw

### DIFF
--- a/src/i18n/de/index.js
+++ b/src/i18n/de/index.js
@@ -1733,6 +1733,7 @@ export default {
   "Public": "Öffentlich",
   "Retrying": "Erneuter Versuch",
   "Publish failed": "Veröffentlichung fehlgeschlagen",
-  "Not published yet": "Noch nicht veröffentlicht"
-
+  "Not published yet": "Noch nicht veröffentlicht",
+  "Bolt Card PIN": "Bolt Card PIN",
+  "Enter your 4-digit card PIN to authorize this withdrawal": "Gib deine 4-stellige Karten-PIN ein, um diese Auszahlung zu bestätigen"
 }

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -1753,5 +1753,7 @@ export default {
   "Public": "Public",
   "Retrying": "Retrying",
   "Publish failed": "Publish failed",
-  "Not published yet": "Not published yet"
+  "Not published yet": "Not published yet",
+  "Bolt Card PIN": "Bolt Card PIN",
+  "Enter your 4-digit card PIN to authorize this withdrawal": "Enter your 4-digit card PIN to authorize this withdrawal"
 }

--- a/src/i18n/es/index.js
+++ b/src/i18n/es/index.js
@@ -1732,5 +1732,7 @@ export default {
   "Public": "Público",
   "Retrying": "Reintentando",
   "Publish failed": "Publicación fallida",
-  "Not published yet": "Aún no publicado"
+  "Not published yet": "Aún no publicado",
+  "Bolt Card PIN": "PIN de Bolt Card",
+  "Enter your 4-digit card PIN to authorize this withdrawal": "Ingresa tu PIN de 4 dígitos para autorizar este retiro"
 }

--- a/src/pages/Wallet.vue
+++ b/src/pages/Wallet.vue
@@ -576,6 +576,20 @@
       @closed="onWithdrawSuccessClosed"
     />
 
+    <!-- Bolt Card PIN dialog — shown when withdrawRequest has pinLimit
+         and amount >= pinLimit. Uses 4-digit numeric entry per LUD-XX spec. -->
+    <PinEntryDialog
+      v-model="showBoltCardPinDialog"
+      :title="$t('Bolt Card PIN')"
+      :subtitle="$t('Enter your 4-digit card PIN to authorize this withdrawal')"
+      :pin-length="4"
+      mode="enter"
+      :show-back-button="true"
+      :error-message="boltCardPinError"
+      @pin-complete="onBoltCardPinComplete"
+      @cancel="onBoltCardPinCancel"
+    />
+
     <!-- LUD-04 (LNURL-auth) identity dialog. Mounted at the wallet page
          level so deep-link, QR scan, and pasted-input flows all funnel
          into the same confirm → sign → submit → record pipeline. -->
@@ -667,6 +681,7 @@ import {haptics} from '../utils/haptics.js';
 import NumberFlow from '@number-flow/vue';
 import {createPaymentMonitor, PaymentStatus, checkNWCPaymentStatus} from '../utils/paymentMonitor.js';
 import PaymentConfirmation from '../components/PaymentConfirmation.vue';
+import PinEntryDialog from '../components/PinEntryDialog.vue';
 import {useWalletStore} from '../stores/wallet';
 import {useAddressBookStore} from '../stores/addressBook';
 import {useTransactionMetadataStore} from '../stores/transactionMetadata';
@@ -709,6 +724,7 @@ export default {
     BackupBanner,
     IdentityAuthDialog,
     ContactAvatar,
+    PinEntryDialog,
   },
   setup() {
     const walletStore = useWalletStore();
@@ -816,6 +832,10 @@ export default {
       lnurlWithdrawStatus: 'idle',
       lnurlWithdrawError: null,
       lnurlWithdrawInvoice: null,
+      // Bolt Card PIN dialog (LUD-XX pinLimit)
+      showBoltCardPinDialog: false,
+      boltCardPinError: '',
+      boltCardPinResolve: null,
       withdrawPaymentMonitor: null,
       withdrawSparkUnsubscribe: null,
       showWithdrawSuccess: false,
@@ -2828,11 +2848,23 @@ export default {
         const invoice = await this.createInvoiceForWithdraw(amountSats, description);
         this.lnurlWithdrawInvoice = invoice;
 
-        // Step 2: Submit callback to withdraw service
-        this.lnurlWithdrawStatus = 'submitting';
-        await this.submitWithdrawCallback(this.pendingPayment, invoice.payment_request);
+        // Step 2: PIN check (LUD-XX pinLimit) — required when amount >= threshold
+        let pin = null;
+        const pinLimit = this.pendingPayment.pinLimit;
+        if (pinLimit && amountSats * 1000 >= pinLimit) {
+          pin = await this.requestBoltCardPin();
+          if (!pin) {
+            // User cancelled PIN entry — silently reset to idle
+            this.resetWithdrawState();
+            return;
+          }
+        }
 
-        // Step 3: Monitor for incoming payment
+        // Step 3: Submit callback to withdraw service
+        this.lnurlWithdrawStatus = 'submitting';
+        await this.submitWithdrawCallback(this.pendingPayment, invoice.payment_request, pin);
+
+        // Step 4: Monitor for incoming payment
         this.lnurlWithdrawStatus = 'monitoring';
         await this.startWithdrawPaymentMonitor(invoice, amountSats);
 
@@ -2902,10 +2934,13 @@ export default {
       };
     },
 
-    async submitWithdrawCallback(withdrawData, bolt11) {
+    async submitWithdrawCallback(withdrawData, bolt11, pin = null) {
       const callbackUrl = new URL(withdrawData.callback);
       callbackUrl.searchParams.set('k1', withdrawData.k1);
       callbackUrl.searchParams.set('pr', bolt11);
+      if (pin) {
+        callbackUrl.searchParams.set('pin', pin);
+      }
 
       const response = await fetch(callbackUrl.toString());
       if (!response.ok) {
@@ -3113,6 +3148,34 @@ export default {
       this.lnurlWithdrawInvoice = null;
       this.withdrawConfirmedAmount = 0;
       this.withdrawConfirmedFiat = '';
+    },
+
+    // ========================================================================
+    // Bolt Card PIN helpers (LUD-XX pinLimit)
+    // ========================================================================
+
+    requestBoltCardPin() {
+      return new Promise((resolve) => {
+        this.boltCardPinError = '';
+        this.boltCardPinResolve = resolve;
+        this.showBoltCardPinDialog = true;
+      });
+    },
+
+    onBoltCardPinComplete(pin) {
+      this.showBoltCardPinDialog = false;
+      if (this.boltCardPinResolve) {
+        this.boltCardPinResolve(pin);
+        this.boltCardPinResolve = null;
+      }
+    },
+
+    onBoltCardPinCancel() {
+      this.showBoltCardPinDialog = false;
+      if (this.boltCardPinResolve) {
+        this.boltCardPinResolve(null);
+        this.boltCardPinResolve = null;
+      }
     },
 
     startMerchantCountdown() {
@@ -3895,7 +3958,8 @@ export default {
             maxSats,
             isFixedAmount,
             fixedAmountSats: isFixedAmount ? maxSats : null,
-            defaultDescription: data.defaultDescription || 'Withdrawal'
+            defaultDescription: data.defaultDescription || 'Withdrawal',
+            pinLimit: data.pinLimit || null
           };
         }
 


### PR DESCRIPTION
## Summary

Implements the [LUD-XX `pinLimit` spec](https://github.com/AxelHamburch/luds/blob/draft/pinlimit-withdrawrequest/XX.md)
for LNURL-withdraw in the terminal (Bolt Card) flow.

When a `withdrawRequest` response contains a `pinLimit` field and the intended
withdrawal amount is **≥ the threshold**, BuhoGO now prompts the user for a
4-digit PIN before submitting the callback — exactly as the spec requires.

This is the wallet-side counterpart to
[lnbits/boltcards#67](https://github.com/lnbits/boltcards/pull/67), which adds
`pinLimit` support on the LNbits service side.

## Flow

1. User taps Bolt Card → `withdrawRequest` arrives with `pinLimit`
2. User slides to confirm amount
3. Invoice is created
4. **NEW:** If `amount × 1000 >= pinLimit` → fullscreen 4-digit PIN dialog appears
5. User enters PIN → callback is sent with `?k1=…&pr=…&pin=1234`
6. Wrong PIN → server returns `ERROR "Invalid PIN"` → user can retry by sliding again
7. User cancels PIN dialog → withdrawal resets silently to idle

## Changes

| File | What |
|---|---|
| `src/pages/Wallet.vue` | `pinLimit` forwarded from `fetchLNURLInfo`; PIN state + 3 methods; `executeWithdraw` PIN check; `submitWithdrawCallback` +`pin` param; `PinEntryDialog` import + template |
| `src/i18n/en-US/index.js` | 2 new keys |
| `src/i18n/de/index.js` | 2 new keys |
| `src/i18n/es/index.js` | 2 new keys |

## Spec compliance

- ✅ PIN collected only when `amount >= pinLimit` (msats comparison)
- ✅ PIN is exactly 4 digits numeric
- ✅ Invoice amount visible before PIN entry (PaymentConfirmSheet stays mounted behind dialog)
- ✅ No PIN = no bypass — cancelling resets the flow without submitting
- ✅ HTTPS required (inherited from existing LNURL-withdraw constraint)

## Test plan

- [ ] Tap a Bolt Card whose LNbits wallet has `pinLimit` set → PIN dialog appears
- [ ] Enter correct PIN → withdrawal succeeds
- [ ] Enter wrong PIN → `Invalid PIN` error shown, can retry
- [ ] Enter wrong PIN 3× → `Card blocked` error shown
- [ ] Cancel PIN dialog → sheet resets cleanly to idle, no callback sent
- [ ] Tap a card **without** `pinLimit` → no PIN dialog, existing flow unchanged
