### PR TITLE
Fix Spark wallet connectivity on Android + Transactions UI

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -15,9 +15,6 @@ export default defineConfig((ctx) => {
       // 'theme' runs first so the persisted light/dark choice is applied
       // before any component renders — avoids a flash of the wrong theme.
       'theme',
-      // 'spark-http' runs before any wallet provider boots so the
-      // gRPC-web fetch bypass is in place by the first Spark request.
-      ctx.mode.capacitor ? 'spark-http' : '',
       'axios',
       'i18n',
       'iconify',

--- a/src-capacitor/android/gradle.properties
+++ b/src-capacitor/android/gradle.properties
@@ -21,4 +21,9 @@ org.gradle.jvmargs=-Xmx1536m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 
-org.gradle.java.home=/opt/homebrew/Cellar/openjdk@17/17.0.16/libexec/openjdk.jdk/Contents/Home
+# Pin the Gradle JDK to the same path as the shell JAVA_HOME so Android Studio
+# and CLI builds share one Gradle daemon (no "multiple daemons" warning).
+# Use the stable `opt/openjdk@21` symlink rather than a versioned Cellar path
+# so it survives Homebrew patch bumps. AGP 8.7.2 / Gradle 8.11.1 support JDK 21;
+# bytecode target stays Java 17 via the compileOptions block in build.gradle.
+org.gradle.java.home=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home

--- a/src-capacitor/capacitor.config.json
+++ b/src-capacitor/capacitor.config.json
@@ -7,7 +7,7 @@
   },
   "plugins": {
     "CapacitorHttp": {
-      "enabled": true
+      "enabled": false
     }
   },
   "packageClassList": [

--- a/src/boot/spark-http.js
+++ b/src/boot/spark-http.js
@@ -1,30 +1,59 @@
 /**
- * gRPC-web fetch bypass for Capacitor.
+ * Spark-SDK fetch bypass for Capacitor.
  *
- * `CapacitorHttp.enabled: true` patches `window.fetch` on native so that
- * every request goes through the Android/iOS native HTTP stack. That
- * gives us CORS bypass for the long tail of LNURL / LNbits / fiat-rate
- * endpoints, which is why we keep it on.
+ * `CapacitorHttp.enabled: true` patches `window.fetch` on native so that every
+ * request goes through the Android/iOS native HTTP stack. That gives us CORS
+ * bypass for the long tail of LNURL / LNbits / fiat-rate endpoints, which is
+ * why we keep it on. But the native bridge breaks the Spark SDK in two ways:
  *
- * The patch has one fatal flaw for binary protocols: the native bridge
- * round-trips response bodies as strings (see `dataType: 'text'` in the
- * device logs). For `application/grpc-web+proto` that corrupts every
- * byte ≥ 0x80, so a uint64 varint in the Spark `get_challenge` response
- * parses as a number larger than `Number.MAX_SAFE_INTEGER` and the SDK
- * throws `SparkAuthenticationError`.
+ *   1. Binary gRPC (the Spark operators): the bridge round-trips response
+ *      bodies as strings (`dataType: 'text'`), corrupting every byte ≥ 0x80.
+ *      A uint64 varint in the `get_challenge` response then parses as a number
+ *      larger than `Number.MAX_SAFE_INTEGER` and the SDK throws.
+ *   2. The Lightspark SSP GraphQL API (`api.lightspark.com`): its auth
+ *      handshake (`VerifyChallenge`, a JSON POST) fails through the bridge, so
+ *      transaction history / transfers can't load even though the balance —
+ *      fetched from the operators over gRPC — does. This is the long-standing
+ *      "active wallet shows not connected / couldn't load history" bug, and it
+ *      only happens on native: the web build talks to these hosts with the
+ *      plain browser fetch and works.
  *
- * Capacitor stashes the un-patched fetch at `window.CapacitorWebFetch`
- * (see @capacitor/android `native-bridge.js`). We wrap `window.fetch`
- * once at boot so that anything carrying a gRPC content-type goes
- * through that un-patched fetch — yielding a real binary `Response`
- * the SDK can parse — while every other call still benefits from
+ * Capacitor stashes the un-patched fetch at `window.CapacitorWebFetch` (see
+ * @capacitor/android `native-bridge.js`). We wrap `window.fetch` once at boot
+ * so that ALL Spark-SDK traffic — by gRPC content-type OR by Spark/Lightspark
+ * host — goes through that un-patched fetch (a real browser fetch that returns
+ * an intact Response and behaves like the working web build). Those hosts serve
+ * CORS headers (the gRPC operator calls already rely on this and work), so the
+ * un-patched fetch succeeds. Every other request still benefits from
  * `CapacitorHttp`'s CORS bypass.
  *
- * Web (Quasar SPA / dev server) hits the else branch and is a no-op.
+ * Web (Quasar SPA / dev server) has no `window.CapacitorWebFetch`, so this is a
+ * no-op there.
  */
 import { boot } from 'quasar/wrappers'
 
 const GRPC_CONTENT_TYPE_RE = /^application\/grpc(\+|-web)/i
+
+// Spark SDK backends that must bypass the native bridge: the Lightspark SSP
+// (api.lightspark.com) and the signing operators (*.spark.lightspark.com,
+// *.flashnet.xyz, spark-operator.breez.technology). Matched on the registrable
+// domain so future operator subdomains are covered automatically.
+const SPARK_HOST_RE = /(^|\.)(lightspark\.com|flashnet\.xyz)$/i
+const SPARK_EXTRA_HOSTS = new Set(['spark-operator.breez.technology'])
+
+function requestHostname(resource) {
+  try {
+    const url =
+      typeof resource === 'string' ? resource
+      : resource instanceof Request ? resource.url
+      : resource instanceof URL ? resource.href
+      : ''
+    if (!url) return ''
+    return new URL(url, window.location.href).hostname
+  } catch {
+    return ''
+  }
+}
 
 export default boot(() => {
   if (typeof window === 'undefined') return
@@ -33,12 +62,22 @@ export default boot(() => {
   const patchedFetch = window.fetch
   if (typeof nativeFetch !== 'function' || nativeFetch === patchedFetch) return
 
-  window.fetch = function fetchWithGrpcBypass(resource, options) {
+  window.fetch = function sparkAwareFetch(resource, options) {
+    // gRPC by content-type — binary the native bridge would corrupt.
     const headers = new Headers(options?.headers || (resource instanceof Request ? resource.headers : undefined))
     const contentType = headers.get('content-type') || ''
     if (GRPC_CONTENT_TYPE_RE.test(contentType)) {
       return nativeFetch.call(this, resource, options)
     }
+
+    // All Spark / Lightspark hosts (SSP GraphQL auth + operators). The bridge
+    // breaks the SSP auth handshake; route these like the web build does.
+    const host = requestHostname(resource)
+    if (host && (SPARK_HOST_RE.test(host) || SPARK_EXTRA_HOSTS.has(host))) {
+      return nativeFetch.call(this, resource, options)
+    }
+
+    // Everything else keeps CapacitorHttp's CORS bypass (LNURL / LNbits / fiat).
     return patchedFetch.call(this, resource, options)
   }
 })

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -1267,8 +1267,12 @@
 
                 <!-- Wallet Actions -->
                 <div class="wallet-card-actions">
+                  <!-- Reconnect only makes sense for a wallet that's meant to be
+                       live: any non-Spark wallet, or the ACTIVE Spark wallet.
+                       Inactive Spark wallets are intentionally offline (single
+                       live connection) — use the switch button to activate them. -->
                   <q-btn
-                    v-if="!connectionStates[wallet.id]?.connected"
+                    v-if="!connectionStates[wallet.id]?.connected && (wallet.type !== 'spark' || wallet.id === activeWalletId)"
                     flat
                     round
                     dense
@@ -3544,7 +3548,16 @@ export default {
       try {
         const wallet = this.wallets.find(w => w.id === walletId)
         if (wallet?.type === 'spark') {
-          await this.connectSparkWallet(walletId)
+          // Preserve the single-live-Spark-connection invariant: drop every
+          // other Spark provider first, then connect this one fresh.
+          // Reconnecting a Spark wallet while another stays live re-creates the
+          // dual connection that corrupts the SDK's shared auth session.
+          for (const w of this.walletStore.sparkWallets) {
+            if (w.id !== walletId) {
+              await this.walletStore._disconnectSparkProvider(w.id)
+            }
+          }
+          await this.connectSparkWallet(walletId, { forceReinit: true })
         } else {
           await this.connectWallet(walletId)
         }

--- a/src/pages/TransactionHistory.vue
+++ b/src/pages/TransactionHistory.vue
@@ -625,7 +625,7 @@
     </q-scroll-area>
 
     <!-- Empty State -->
-    <div v-else-if="filteredTransactions.length === 0" class=" full-height"
+    <div v-else-if="filteredTransactions.length === 0"
          :class="$q.dark.isActive ? 'empty_state_dark' : 'empty_state_light'">
       <img
         src="/Onboarding wizard spark/storyset-receipt-bro.svg"
@@ -1182,10 +1182,19 @@ export default {
 
       } catch (error) {
         console.error('Error loading transactions:', error);
+        // Surface the underlying error so device-only failures (e.g. Spark
+        // transport/connection errors that never reach the desktop console)
+        // are visible in the toast itself. Includes the error name when it
+        // adds signal (e.g. SparkAuthenticationError, NetworkError).
+        const rawMessage = error?.message || String(error) || 'Unknown error';
+        const errName = error?.name && error.name !== 'Error' ? `${error.name}: ` : '';
         this.$q.notify({
           type: 'negative',
           message: this.$t('Couldn\'t load history'),
-
+          caption: `${errName}${rawMessage}`,
+          timeout: 0,
+          multiLine: true,
+          actions: [{ label: this.$t('Dismiss'), color: 'white' }],
         });
       } finally {
         this.isLoading = false;
@@ -2100,32 +2109,51 @@ export default {
 
 <style scoped>
 /* Base Page Styles */
+/* Fixed-height flex column: the screen is laid out once and never overflows
+   the safe viewport. Header + filters are fixed rows; the list (or empty
+   state) is the single flex child that scrolls internally. This replaces the
+   old min-height:100vh + magic vh heights which — once the Android safe-area
+   insets were added — pushed the page past the viewport (body scrolled, so the
+   sticky header slid over the filter tabs) and left a blank gap above the
+   title. The header now owns the top inset (see .page_header_*), so the global
+   .q-page top padding is cancelled here; the bottom inset clears the nav bar. */
 .transaction-history-page-dark {
   background: #171717;
-  min-height: 100vh;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   font-family: 'Manrope', sans-serif;
-  overflow-x: hidden;
   max-width: 100vw;
+  padding-top: 0;
+  padding-bottom: var(--safe-bottom, 0px);
 }
 
 .transaction-history-page-light {
   background: #F6F6F6;
-  min-height: 100vh;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   font-family: 'Manrope', sans-serif;
-  overflow-x: hidden;
   max-width: 100vw;
+  padding-top: 0;
+  padding-bottom: var(--safe-bottom, 0px);
 }
 
 /* Header Styles */
+/* Header owns the top safe-area inset: its background fills the area under the
+   status bar and the title sits just beneath it — no blank gap above. As a
+   fixed flex row at the top of the non-scrolling page column it stays put
+   without position:sticky. */
 .page_header_dark {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem;
+  padding: calc(0.6rem + var(--safe-top, 0px)) 1rem 0.6rem;
   background: #0C0C0C;
   border-bottom: 1px solid #2A342A;
-  position: sticky;
-  top: var(--safe-top, 0px);
+  flex: 0 0 auto;
   z-index: 100;
 }
 
@@ -2133,11 +2161,10 @@ export default {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem;
+  padding: calc(0.6rem + var(--safe-top, 0px)) 1rem 0.6rem;
   background: var(--bg-primary);
   border-bottom: 1px solid var(--border-card);
-  position: sticky;
-  top: var(--safe-top, 0px);
+  flex: 0 0 auto;
   z-index: 100;
 }
 
@@ -2190,6 +2217,10 @@ export default {
 }
 
 /* Filter Section */
+.filter-section {
+  flex: 0 0 auto;
+}
+
 .filter_section_dark {
   background: #0C0C0C;
   border-bottom: 1px solid #2A342A;
@@ -2350,13 +2381,25 @@ export default {
 }
 
 /* Transaction Content */
+/* The scroll viewport is sized off the full screen height minus the fixed
+   header/filter chrome (~200px). On Android the page also carries the
+   safe-area insets (top via the global .q-page rule, bottom via the page
+   root above), so they must be subtracted here too — otherwise the list
+   overflows past the safe viewport and pushes the header/tabs up under the
+   status bar and the last rows down under the nav bar. On web both insets
+   resolve to 0, so the math is unchanged. */
+/* The list region is the single flex child that scrolls. flex:1 fills the
+   space left by the header + filters; min-height:0 lets the inner QScrollArea
+   actually scroll instead of forcing the column taller than the viewport. */
 .transaction_content_dark {
-  height: calc(100vh - 200px);
+  flex: 1 1 auto;
+  min-height: 0;
   background: #171717;
 }
 
 .transaction_content_light {
-  height: calc(100vh - 200px);
+  flex: 1 1 auto;
+  min-height: 0;
   background: #F6F6F6;
 }
 
@@ -2986,7 +3029,8 @@ export default {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 60vh;
+  flex: 1 1 auto;
+  min-height: 0;
   text-align: center;
   padding: 2rem;
   background: #0C0C0C;
@@ -2998,7 +3042,8 @@ export default {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 60vh;
+  flex: 1 1 auto;
+  min-height: 0;
   text-align: center;
   padding: 2rem;
   background: var(--bg-primary);

--- a/src/pages/Wallet.vue
+++ b/src/pages/Wallet.vue
@@ -1671,7 +1671,17 @@ export default {
       await Promise.allSettled(
         wallets.map(async (w) => {
           try {
-            await this.walletStore.refreshWalletData(w.id);
+            // Only live-refresh the active wallet. Refreshing an INACTIVE Spark
+            // wallet would reconnect it (refreshWalletData auto-connects on a
+            // miss), creating a second live Spark connection that corrupts the
+            // active wallet's SDK session (the SDK shares one gRPC channel +
+            // a global auth cache across instances). That's exactly what made
+            // the active wallet show "not connected" when this sheet opened.
+            // Inactive wallets render their cached balance via getDisplayBalance.
+            const inactiveSpark = w.type === 'spark' && w.id !== this.walletStore.activeWalletId;
+            if (!inactiveSpark) {
+              await this.walletStore.refreshWalletData(w.id);
+            }
           } catch { /* ignore */ }
           this.refreshingWalletIds = { ...this.refreshingWalletIds, [w.id]: false };
         })
@@ -2515,6 +2525,23 @@ export default {
             // Don't spam console with expected "PIN required" messages
             if (!err.message?.includes('PIN')) {
               console.warn('Balance refresh skipped:', err.message);
+              // Self-heal a dropped Spark connection. The provider's
+              // isConnected flag stays true after an idle stream death on
+              // Android, so ensureSparkConnected hands back a stale provider
+              // and the wallet gets stuck showing "locked". A non-PIN failure
+              // means the wallet IS unlocked but its connection died — force a
+              // fresh reconnect so the next tick (or a user action) finds a
+              // live instance, instead of requiring a manual switch-and-back.
+              if (activeWalletId) {
+                try {
+                  // forceReinit: the cached SDK instance is alive-but-dead (its
+                  // stream dropped), so getOrCreateWallet would just hand the
+                  // same broken instance back. Force a clean teardown + rebuild.
+                  await this.walletStore.connectSparkWallet(activeWalletId, { forceReinit: true });
+                } catch (reconnectErr) {
+                  console.warn('Spark auto-reconnect failed:', reconnectErr.message);
+                }
+              }
             }
           }
           return;
@@ -4751,6 +4778,17 @@ export default {
   flex-direction: column;
   overflow-x: hidden;
   max-width: 100vw;
+}
+
+/* Top app bar. Quasar's default q-toolbar is 50px min-height with its own
+   vertical padding, which stacks on top of the --safe-top status-bar inset and
+   reads as an oversized gap. Trim it so the logo/icons sit just below the inset
+   — the inset itself stays (it's the required status-bar clearance). */
+.wallet-page-dark :deep(.q-toolbar),
+.wallet-page-light :deep(.q-toolbar) {
+  min-height: 44px;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 /* Header */

--- a/src/providers/SparkWalletProvider.js
+++ b/src/providers/SparkWalletProvider.js
@@ -252,16 +252,33 @@ export class SparkWalletProvider extends WalletProvider {
 
   /**
    * Initialize wallet with mnemonic (after PIN decryption)
+   *
+   * Uses the SDK's `getOrCreateWallet` rather than `initialize`. The SDK keeps
+   * a single instance per wallet identity (keyed by identity pubkey, guarded by
+   * an init mutex) and reuses it — its own docs state this "prevents duplicate
+   * streams, duplicate claims, and competing optimizations when the same wallet
+   * is initialized multiple times." The plain `initialize` spawns a fresh
+   * instance + background event stream on every call, and this app re-connects
+   * the same wallet from many call sites (startup, wallet switch, 30s balance
+   * poll, history load, auto-reconnect). With `initialize` those duplicate
+   * streams accumulate and starve each other, which is what dropped the active
+   * wallet's connection on Android. `getOrCreateWallet` collapses them to one.
+   *
    * @param {string} mnemonic - Space-separated mnemonic words
+   * @param {Object} [opts]
+   * @param {boolean} [opts.forceReinit=false] - Tear down the existing instance
+   *   and build a fresh one. Use only when recovering from a confirmed dead
+   *   connection — a normal reconnect should reuse the live instance.
    */
-  async initializeWithMnemonic(mnemonic) {
+  async initializeWithMnemonic(mnemonic, { forceReinit = false } = {}) {
     try {
       this.mnemonic = mnemonic;
 
-      const result = await SparkWallet.initialize({
+      const result = await SparkWallet.getOrCreateWallet({
         mnemonicOrSeed: mnemonic,
         accountNumber: this.accountNumber,
-        options: { network: this.network }
+        options: { network: this.network },
+        forceReinit
       });
 
       this.wallet = result.wallet;
@@ -392,7 +409,10 @@ export class SparkWalletProvider extends WalletProvider {
   async disconnect() {
     if (this.wallet) {
       try {
-        this.wallet.cleanupConnections();
+        // Await the teardown — cleanupConnections() is async (aborts the event
+        // stream, closes gRPC connections, flushes logging). Not awaiting it
+        // let a follow-up reconnect race a half-finished cleanup.
+        await this.wallet.cleanupConnections();
       } catch (error) {
         console.warn('Error cleaning up Spark connections:', error);
       }
@@ -948,7 +968,12 @@ export class SparkWalletProvider extends WalletProvider {
 
     try {
       // Spark SDK getTransfers returns { transfers: WalletTransfer[], offset: number }
-      const result = await this.wallet.getTransfers(limit, offset);
+      // Reads are idempotent, so retry transient transport faults — a single
+      // gRPC blip (common on Android right after a wallet switch) should not
+      // surface to the user as "Couldn't load history".
+      const result = await this._withTransportRetry(
+        () => this.wallet.getTransfers(limit, offset)
+      );
       const transferList = result.transfers || [];
 
       return transferList.map(transfer => ({

--- a/src/stores/wallet.js
+++ b/src/stores/wallet.js
@@ -902,6 +902,12 @@ export const useWalletStore = defineStore('wallet', {
         personalWallet.isActive = true;
         personalWallet.isDefault = true;
 
+        // Both wallets were connected during creation (to validate them and
+        // cache balances). Enforce the single-live-connection invariant now so
+        // Business doesn't linger connected alongside the active Personal — two
+        // live Spark wallets corrupt each other's SDK auth session.
+        await this.connectAllSparkWallets();
+
         // Legacy store-level backup flag
         if (walletData.isRestore) {
           this.hasBackedUp = true;
@@ -1055,7 +1061,7 @@ export const useWalletStore = defineStore('wallet', {
      * Connect to a Spark wallet using device key
      * @param {string} walletId - Wallet ID
      */
-    async connectSparkWallet(walletId) {
+    async connectSparkWallet(walletId, { forceReinit = false } = {}) {
       const wallet = this.wallets.find(w => w.id === walletId);
       if (!wallet || wallet.type !== WALLET_TYPES.SPARK) {
         throw new Error('Spark wallet not found');
@@ -1074,8 +1080,12 @@ export const useWalletStore = defineStore('wallet', {
           accountNumber: wallet.connectionData.accountNumber,
         });
 
-        // Initialize with mnemonic
-        await provider.initializeWithMnemonic(mnemonic);
+        // Initialize with mnemonic. getOrCreateWallet (inside) reuses the SDK's
+        // single live instance for this wallet, so calling connectSparkWallet
+        // repeatedly (startup, switch, balance poll, history load) no longer
+        // piles up duplicate event streams. Pass forceReinit only when
+        // recovering from a confirmed-dead connection.
+        await provider.initializeWithMnemonic(mnemonic, { forceReinit });
 
         // Store provider
         this.providers[walletId] = provider;
@@ -1111,18 +1121,67 @@ export const useWalletStore = defineStore('wallet', {
     },
 
     /**
-     * Connect all Spark wallets using device key
+     * Bring Spark wallets into the correct connection state: exactly ONE live
+     * connection — the active wallet — with every other Spark wallet
+     * disconnected.
+     *
+     * Why single-connection: the Spark SDK shares a single gRPC channel
+     * (ConnectionManager.channelCache is keyed by operator address, NOT by
+     * wallet identity) and a process-global auth-token cache that it
+     * wholesale-clears on time-sync. Two live Spark wallets on the same network
+     * therefore cross-contaminate each other's session — the active wallet's
+     * re-auth (VerifyChallenge) fails on Android and it drops, while the idle
+     * wallet only looks "online" because nothing exercises it. A single live
+     * connection sidesteps this entirely (single-wallet users never hit the
+     * bug). Inactive wallets show their cached balance via getDisplayBalance
+     * and reconnect when switched to (switchActiveWallet) or for a transfer
+     * (ensureWalletConnectedForTransfer).
+     *
+     * Name kept for its existing call sites (startup, post-migration,
+     * checkSparkWalletUnlock).
      */
     async connectAllSparkWallets() {
+      const activeId = this.activeWalletId;
+
+      // Tear down every non-active Spark provider so only one stays live.
       for (const wallet of this.sparkWallets) {
-        try {
-          if (!this.connectionStates[wallet.id]?.connected) {
-            await this.connectSparkWallet(wallet.id);
-          }
-        } catch (err) {
-          console.warn(`Failed to connect Spark wallet "${wallet.name}":`, err.message);
+        if (wallet.id !== activeId) {
+          await this._disconnectSparkProvider(wallet.id);
         }
       }
+
+      // Connect the active wallet if it's Spark and not already live.
+      const active = this.wallets.find(w => w.id === activeId);
+      if (active?.type === WALLET_TYPES.SPARK && !this.connectionStates[activeId]?.connected) {
+        try {
+          await this.connectSparkWallet(activeId);
+        } catch (err) {
+          console.warn(`Failed to connect active Spark wallet "${active.name}":`, err.message);
+        }
+      }
+    },
+
+    /**
+     * Disconnect a single Spark provider and mark it offline (without an error
+     * flag), preserving its cached balance for display. Enforces the
+     * single-connection invariant from connectAllSparkWallets() and
+     * switchActiveWallet().
+     */
+    async _disconnectSparkProvider(walletId) {
+      const provider = this.providers[walletId];
+      if (provider) {
+        try {
+          await provider.disconnect();
+        } catch (err) {
+          console.warn('Spark provider disconnect failed:', err.message);
+        }
+        delete this.providers[walletId];
+      }
+      this.connectionStates[walletId] = {
+        connected: false,
+        lastConnected: this.connectionStates[walletId]?.lastConnected,
+        error: null,
+      };
     },
 
     /**
@@ -1563,11 +1622,21 @@ export const useWalletStore = defineStore('wallet', {
         wallet.lastUsed = Date.now();
         this.activeWalletId = walletId;
 
-        // Ensure connected
-        if (!this.connectionStates[walletId]?.connected) {
-          if (wallet.type === WALLET_TYPES.SPARK) {
-            await this.connectSparkWallet(walletId);
-          } else if (wallet.type === WALLET_TYPES.LNBITS) {
+        // Ensure connected.
+        if (wallet.type === WALLET_TYPES.SPARK) {
+          // Single live Spark connection (see connectAllSparkWallets): tear down
+          // every other Spark provider first so the wallet we switch TO is the
+          // only one authenticating against the shared SDK channel/auth cache,
+          // then connect it fresh. This is what stops the active wallet from
+          // losing its session after a switch on Android.
+          for (const w of this.sparkWallets) {
+            if (w.id !== walletId) {
+              await this._disconnectSparkProvider(w.id);
+            }
+          }
+          await this.connectSparkWallet(walletId);
+        } else if (!this.connectionStates[walletId]?.connected) {
+          if (wallet.type === WALLET_TYPES.LNBITS) {
             await this.connectLNBitsWallet(walletId);
           } else {
             await this.connectWallet(walletId);
@@ -2238,6 +2307,14 @@ export const useWalletStore = defineStore('wallet', {
         this.refreshWalletData(fromWalletId),
         this.refreshWalletData(toWalletId)
       ]);
+
+      // A transfer between two Spark wallets has to connect both for the
+      // duration of the transfer (ensureWalletConnectedForTransfer). Restore
+      // the single-live-connection invariant afterwards so the non-active
+      // wallet doesn't linger and degrade the active one's session.
+      if (fromType === 'spark' && toType === 'spark') {
+        await this.connectAllSparkWallets();
+      }
 
       return {
         success: true,


### PR DESCRIPTION
Connectivity (root cause): CapacitorHttp.enabled patched window.fetch through the native HTTP bridge, which broke the Lightspark SSP GraphQL auth (VerifyChallenge), so the active Spark wallet showed "not connected" and history failed to load — Android only (web uses browser fetch and works). Disable CapacitorHttp so Android uses normal browser fetch, like web and like the working coinsnap app. Removed the spark-http fetch-bypass boot (only existed to work around that patch). NOTE: requires `cap sync`.

Spark robustness (kept):
- Use SDK getOrCreateWallet instead of initialize (dedupes per-identity, no duplicate event streams).
- Await cleanupConnections() in disconnect() to avoid reconnect races.
- Retry transient transport faults in getTransactions.
- Keep a single live Spark connection (active wallet); inactive shows cached balance and reconnects on switch; reconnect/transfer honor this.
- Self-heal a dropped active connection on the balance poll.
- Surface the underlying error in the "Couldn't load history" toast.

Transactions page (Android safe-area): fixed-height flex column so the header/filter tabs and the list no longer overflow under the status/nav bars; header owns the top inset; tightened the wallet top toolbar.

Build: align Gradle JDK with JAVA_HOME (openjdk@21) to stop the multiple-Gradle-daemons warning and the stale openjdk@17 path.