### PR TITLE
Revert debug error text in "Couldn't load history" toast

### DIFF
--- a/src/pages/TransactionHistory.vue
+++ b/src/pages/TransactionHistory.vue
@@ -1182,19 +1182,9 @@ export default {
 
       } catch (error) {
         console.error('Error loading transactions:', error);
-        // Surface the underlying error so device-only failures (e.g. Spark
-        // transport/connection errors that never reach the desktop console)
-        // are visible in the toast itself. Includes the error name when it
-        // adds signal (e.g. SparkAuthenticationError, NetworkError).
-        const rawMessage = error?.message || String(error) || 'Unknown error';
-        const errName = error?.name && error.name !== 'Error' ? `${error.name}: ` : '';
         this.$q.notify({
           type: 'negative',
           message: this.$t('Couldn\'t load history'),
-          caption: `${errName}${rawMessage}`,
-          timeout: 0,
-          multiLine: true,
-          actions: [{ label: this.$t('Dismiss'), color: 'white' }],
         });
       } finally {
         this.isLoading = false;


### PR DESCRIPTION
The verbose, stay-open error caption was a temporary diagnostic to surface the Spark VerifyChallenge failure on-device. Now that the root cause is fixed, restore the short, auto-dismissing user-facing message. The full error is still logged via console.error.