### PR TITLE
Accept lnurl: prefix on scanned/pasted LNURLs

### DIFF
--- a/src-capacitor/android/app/src/main/AndroidManifest.xml
+++ b/src-capacitor/android/app/src/main/AndroidManifest.xml
@@ -22,63 +22,63 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <!-- Deep link: lightning: (BOLT11 invoices, lightning addresses) -->
+            <!-- Deep links: Lightning + LNURL URI schemes.
+                 Android matches <data android:scheme> case-sensitively for
+                 NFC- and app-originated intents (browser links get normalized,
+                 NFC tags do not), so every scheme is declared in both lower-
+                 and upper-case. Covers a bare bech32 LNURL wrapped as
+                 `lightning:` or `lnurl:`, plus the LUD-17 `lnurlp://` /
+                 `lnurlw://` (Bolt Card) forms. -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="lightning" />
+                <data android:scheme="LIGHTNING" />
+                <data android:scheme="lnurl" />
+                <data android:scheme="LNURL" />
+                <data android:scheme="lnurlp" />
+                <data android:scheme="LNURLP" />
+                <data android:scheme="lnurlw" />
+                <data android:scheme="LNURLW" />
             </intent-filter>
 
-            <!-- Deep link: bitcoin: (on-chain addresses) -->
+            <!-- Deep link: bitcoin: (BIP21 on-chain / unified QR). Uppercase
+                 BITCOIN: is common in QR codes (alphanumeric-mode density). -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="bitcoin" />
+                <data android:scheme="BITCOIN" />
             </intent-filter>
 
-            <!-- Deep link: LUD-17 lnurlp:// (LNURL-pay) -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="lnurlp" />
-            </intent-filter>
-
-            <!-- Deep link: LUD-17 lnurlw:// (LNURL-withdraw, Boltcards) -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="lnurlw" />
-            </intent-filter>
-
-            <!-- NFC: Handle NDEF tags (Bolt Cards, LNURL tags, Lightning tags) -->
-            <intent-filter>
-                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="*/*" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="https" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="lnurlw" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="lnurlp" />
-            </intent-filter>
+            <!-- NFC: NDEF tags carrying a Lightning / LNURL URI record (Bolt
+                 Cards -> lnurlw://, LNURL tags, lightning: tags, or a plain
+                 https:// that resolves to an LNURL). Schemes are case-sensitive
+                 here too - see the deep-link note above. -->
             <intent-filter>
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="lightning" />
+                <data android:scheme="LIGHTNING" />
+                <data android:scheme="lnurl" />
+                <data android:scheme="LNURL" />
+                <data android:scheme="lnurlp" />
+                <data android:scheme="LNURLP" />
+                <data android:scheme="lnurlw" />
+                <data android:scheme="LNURLW" />
+                <data android:scheme="https" />
+            </intent-filter>
+
+            <!-- NFC: NDEF tags written as a bare text/URI record with no usable
+                 scheme (a naked `LNURL1...` bech32 or a BOLT11). The MIME
+                 catch-all still routes them to us; nfc.js then classifies the
+                 payload via parsePaymentDestination. -->
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
             </intent-filter>
             <!-- NFC: IsoDep tech dispatch — catches NTAG 424 DNA / Bolt Cards when
                  Android does not fire NDEF_DISCOVERED for T4T tags -->

--- a/src/components/BatchSendModal.vue
+++ b/src/components/BatchSendModal.vue
@@ -616,6 +616,7 @@ import { useQuasar } from 'quasar'
 import { useWalletStore } from '../stores/wallet'
 import { useAddressBookStore } from '../stores/addressBook'
 import LightningPaymentService, { resolveLUD17URL } from '../utils/lightning.js'
+import { stripWrapperScheme } from '../utils/addressUtils'
 import { bech32 } from 'bech32'
 import { getUserFriendlyError, formatInsufficientBalanceBreakdown } from '../utils/userErrors'
 import ContactAvatar from './AddressBook/ContactAvatar.vue'
@@ -1144,7 +1145,7 @@ async function fetchLightningAddressInvoice(address, amountSats) {
 //      fixed amount rather than rejected.
 // Returns { pr, amountSats } so the caller can record the amount actually sent.
 async function fetchLnurlInvoice(lnurl, requestedSats) {
-  const clean = (lnurl || '').trim().replace(/^lightning:/i, '')
+  const clean = stripWrapperScheme(lnurl)
 
   // LUD-17 scheme (lnurlp://…) maps straight to https; otherwise bech32-decode.
   let endpoint = resolveLUD17URL(clean)

--- a/src/components/PaymentModal.vue
+++ b/src/components/PaymentModal.vue
@@ -38,6 +38,7 @@ import LightningPaymentService, { resolveLUD17URL } from '../utils/lightning.js'
 import {
   isLightningInvoice as isLightningInvoiceShared,
   isLnurl as isLnurlShared,
+  stripWrapperScheme,
 } from '../utils/addressUtils.js'
 import PaymentConfirmSheet from './PaymentConfirmSheet.vue'
 
@@ -339,7 +340,7 @@ export default {
      * a manual decode (the NWC + LNbits paths).
      */
     decodeLNURL(lnurl) {
-      const clean = lnurl.trim().replace(/^lightning:/i, '')
+      const clean = stripWrapperScheme(lnurl)
 
       const lud17Url = resolveLUD17URL(clean)
       if (lud17Url) return lud17Url

--- a/src/components/SendModal.vue
+++ b/src/components/SendModal.vue
@@ -251,6 +251,7 @@ import {
   isLnurl,
   isBitcoinAddress,
   isLightningAddress,
+  stripWrapperScheme,
 } from '../utils/addressUtils';
 import { recognizePhoneNumber } from '../services/lnAddressServices';
 import { classifyIdentifier, LOOKUP_ERROR } from '../utils/nostrLookup';
@@ -338,9 +339,7 @@ export default {
         if (parsed) return 'bip21';
       }
 
-      const cleaned = lower.startsWith('lightning:')
-        ? raw.substring(10).trim()
-        : raw;
+      const cleaned = stripWrapperScheme(raw);
 
       if (isSparkAddress(cleaned)) return 'spark';
       if (isLightningInvoice(cleaned)) return 'lightning_invoice';
@@ -723,11 +722,10 @@ export default {
         return { cleaned: destination ? destination.value : '', bip21 };
       }
 
-      if (trimmed.toLowerCase().startsWith('lightning:')) {
-        return { cleaned: trimmed.substring(10), bip21: null };
-      }
-
-      return { cleaned: trimmed, bip21: null };
+      // Unwrap a `lightning:` / `lnurl:` scheme down to the bare payload so the
+      // type classifier and the emitted value are both wrapper-free. No-op when
+      // no wrapper is present.
+      return { cleaned: stripWrapperScheme(trimmed), bip21: null };
     },
 
     determinePaymentType(data) {

--- a/src/pages/Wallet.vue
+++ b/src/pages/Wallet.vue
@@ -754,7 +754,7 @@
 <script>
 import { NostrWebLNProvider } from "@getalby/sdk";
 import {LightningPaymentService, resolveLUD17URL} from '../utils/lightning.js';
-import {isLightningInvoice as isLightningInvoiceShared} from '../utils/addressUtils.js';
+import {isLightningInvoice as isLightningInvoiceShared, stripWrapperScheme} from '../utils/addressUtils.js';
 import {matchLnAddressService, formatPhoneHandle} from '../services/lnAddressServices';
 import {matchWalletBrand} from '../services/walletBrands';
 import {npubFromLightningAddress, shortenNpub, profileDisplayName, sanitizeImageUrl} from '../services/nostrRecipient';
@@ -5192,7 +5192,7 @@ export default {
 
     // Helper: Decode LNURL (bech32 LUD-01 or URL scheme LUD-17) to URL
     decodeLNURL(lnurl) {
-      const clean = lnurl.trim().replace(/^lightning:/i, '');
+      const clean = stripWrapperScheme(lnurl);
 
       // Plain https:// or http:// URL (e.g. Bolt Card NFC URL — already decoded)
       if (/^https?:\/\//i.test(clean)) return clean;

--- a/src/providers/WalletFactory.js
+++ b/src/providers/WalletFactory.js
@@ -15,6 +15,7 @@ import {
   isLightningInvoice,
   isLnurl,
   isBitcoinAddress,
+  stripWrapperScheme,
 } from '../utils/addressUtils';
 
 /**
@@ -132,8 +133,10 @@ export function parsePaymentDestination(input) {
       return { type: 'unknown', valid: false, bip21 };
     }
     cleaned = destination.value;
-  } else if (cleaned.toLowerCase().startsWith('lightning:')) {
-    cleaned = cleaned.substring(10);
+  } else {
+    // Strip a wrapper URI scheme (`lightning:` / `lnurl:`) so the bare payload
+    // reaches the prefix-based branches below. No-op when none is present.
+    cleaned = stripWrapperScheme(cleaned);
   }
 
   // Attach BIP21 metadata (amount, label, message, ...) to every result so

--- a/src/stores/earn.js
+++ b/src/stores/earn.js
@@ -12,6 +12,7 @@
 
 import { defineStore } from 'pinia'
 import { i18n } from '../boot/i18n'
+import { stripWrapperScheme } from '../utils/addressUtils'
 import quizEnUS from '../data/earn-quizzes.en-US.json'
 import quizDe from '../data/earn-quizzes.de.json'
 import quizEs from '../data/earn-quizzes.es.json'
@@ -333,12 +334,14 @@ export const useEarnStore = defineStore('earn', {
      */
     async _fetchWithdrawInfo(lnurl) {
       try {
-        // Decode LNURL (bech32) to URL
-        let url = lnurl
-        if (lnurl.toLowerCase().startsWith('lnurl')) {
+        // Decode LNURL (bech32) to URL. Unwrap any `lightning:` / `lnurl:`
+        // scheme first so a wrapped voucher still decodes.
+        const clean = stripWrapperScheme(lnurl)
+        let url = clean
+        if (clean.toLowerCase().startsWith('lnurl')) {
           // Import bech32 decode from existing utility
           const { bech32 } = await import('bech32')
-          const decoded = bech32.decode(lnurl.toLowerCase(), 2000)
+          const decoded = bech32.decode(clean.toLowerCase(), 2000)
           const bytes = bech32.fromWords(decoded.words)
           url = new TextDecoder().decode(new Uint8Array(bytes))
         }

--- a/src/utils/__tests__/addressUtils.spec.js
+++ b/src/utils/__tests__/addressUtils.spec.js
@@ -20,7 +20,14 @@ import {
   isBitcoinAddress,
   isLightningAddress,
   normalizePaymentAddress,
+  stripWrapperScheme,
 } from '../addressUtils.js';
+
+// A real LNURL-withdraw voucher (LNbits) reported from the field. It must be
+// recognized whether bare, `lightning:`-wrapped, or `lnurl:`-wrapped — the
+// last of which previously fell through to "Unsupported link format".
+const FIELD_LNURL =
+  'LNURL1DP68GURN8GHJ7MRWVF5HGUEWVFHHXTNPVSHHW6T5DPJ8YCTH9ASHQ6F0WCCJ7MRWW4EXCT6VTFG8QAN5XSUHZAT5VDXN2CTJF4ZX6A34FSHKKCTZTF6HGUP4GA8RWVN00FE42SMZVFFXK3S6XM7HC';
 
 let passed = 0;
 let failed = 0;
@@ -61,6 +68,39 @@ test('isSparkAddress: new + legacy prefixes', () => {
 test('isLightningInvoice / isLnurl: tolerate lightning: wrapper', () => {
   assert.equal(isLightningInvoice('lightning:lnbc10n1pjxyz'), true);
   assert.equal(isLnurl('lightning:lnurl1dp68'), true);
+});
+
+test('isLnurl: tolerates the lnurl: wrapper in any case (field regression)', () => {
+  assert.equal(isLnurl(FIELD_LNURL), true);              // bare
+  assert.equal(isLnurl(`lnurl:${FIELD_LNURL}`), true);   // lnurl: wrapper
+  assert.equal(isLnurl(`LNURL:${FIELD_LNURL}`), true);   // uppercase scheme
+  assert.equal(isLnurl(`lightning:${FIELD_LNURL}`), true);
+});
+
+// ---------------------------------------------------------------------------
+// stripWrapperScheme — the single unwrap primitive every path now shares
+// ---------------------------------------------------------------------------
+
+test('stripWrapperScheme: removes lightning: / lnurl: case-insensitively', () => {
+  assert.equal(stripWrapperScheme('lightning:lnbc10n1pjxyz'), 'lnbc10n1pjxyz');
+  assert.equal(stripWrapperScheme(`lnurl:${FIELD_LNURL}`), FIELD_LNURL);
+  assert.equal(stripWrapperScheme(`LNURL:${FIELD_LNURL}`), FIELD_LNURL);
+  assert.equal(stripWrapperScheme('  lightning:lnbc1  '), 'lnbc1'); // trims both sides
+});
+
+test('stripWrapperScheme: leaves bare payloads and LUD-17 schemes untouched', () => {
+  assert.equal(stripWrapperScheme(FIELD_LNURL), FIELD_LNURL);
+  // LUD-17 schemes ARE the type — they must survive, not get clipped to `//…`.
+  assert.equal(stripWrapperScheme('lnurlw://lnbits.bos.ad/x'), 'lnurlw://lnbits.bos.ad/x');
+  assert.equal(stripWrapperScheme('lnurlp://v1.lnbits.de/lnurlp/3RXhUU'), 'lnurlp://v1.lnbits.de/lnurlp/3RXhUU');
+  // The authority-style `lnurl://` alias must not lose its `//host`.
+  assert.equal(stripWrapperScheme('lnurl://host/x'), 'lnurl://host/x');
+});
+
+test('stripWrapperScheme: non-strings → empty string', () => {
+  assert.equal(stripWrapperScheme(null), '');
+  assert.equal(stripWrapperScheme(undefined), '');
+  assert.equal(stripWrapperScheme(42), '');
 });
 
 // ---------------------------------------------------------------------------
@@ -115,6 +155,12 @@ test('LUD-17 lnurlp:// passes through untouched and is recognized', () => {
   const lud17 = 'lnurlp://v1.lnbits.de/lnurlp/3RXhUU';
   assert.equal(normalizePaymentAddress(lud17), lud17);
   assert.equal(isLnurl(lud17), true);
+});
+
+test('lnurl: wrapper around an LNURL unwraps to a recognized LNURL', () => {
+  const bare = normalizePaymentAddress(`lnurl:${FIELD_LNURL}`);
+  assert.equal(bare, FIELD_LNURL);
+  assert.equal(isLnurl(bare), true);
 });
 
 test('passthrough: bare address / npub / nostr URI returned trimmed, untouched', () => {

--- a/src/utils/addressUtils.js
+++ b/src/utils/addressUtils.js
@@ -75,6 +75,44 @@ function norm(value) {
 }
 
 /**
+ * Strip a leading wrapper URI scheme (`lightning:` / `lnurl:`) down to the bare
+ * payload, case-insensitively. Real-world tags, QR codes and deep links carry
+ * the bech32 LNURL (or BOLT11) wrapped in one of these schemes; classification
+ * and bech32 decoding both need it gone first. Inputs without a wrapper are
+ * returned trimmed and otherwise untouched; non-strings yield an empty string.
+ *
+ * Payload casing is preserved: bech32 LNURL / BOLT11 are case-insensitive per
+ * spec, but base58 and some decoders are not, so we only remove the wrapper.
+ *
+ * Two deliberate exclusions keep this from clipping a real payload:
+ *   - LUD-17 schemes (`lnurlp://`, `lnurlw://`, `lnurlc://`, `keyauth://`) — the
+ *     scheme *is* the type. They diverge from `lnurl:` at the character after
+ *     `lnurl`, so the `lnurl:` check never matches them.
+ *   - the authority-style `lnurl://host` alias — stripping `lnurl:` there would
+ *     leave a dangling `//host`, so we only unwrap `lnurl:` when no `//` follows.
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function stripWrapperScheme(value) {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  const lower = trimmed.toLowerCase();
+
+  // `lightning:` is always opaque (no `lightning://` form exists) — unwrap it.
+  if (lower.startsWith('lightning:')) {
+    return trimmed.slice('lightning:'.length).trim();
+  }
+
+  // `lnurl:` wraps a bare bech32 LNURL (`lnurl:LNURL1…`); skip `lnurl://…`.
+  if (lower.startsWith('lnurl:') && !lower.startsWith('lnurl://')) {
+    return trimmed.slice('lnurl:'.length).trim();
+  }
+
+  return trimmed;
+}
+
+/**
  * True if the input looks like a Spark address (any supported prefix).
  * @param {unknown} address
  * @returns {boolean}
@@ -93,19 +131,19 @@ export function isSparkAddress(address) {
  * @returns {boolean}
  */
 export function isLightningInvoice(invoice) {
-  const lower = norm(invoice).replace(/^lightning:/, '');
+  const lower = stripWrapperScheme(invoice).toLowerCase();
   if (!lower) return false;
   return LIGHTNING_INVOICE_HRPS.some(hrp => lower.startsWith(hrp));
 }
 
 /**
  * True if the input looks like an LNURL (bech32 or LUD-17 scheme).
- * A leading `lightning:` wrapper is tolerated.
+ * A leading `lightning:` or `lnurl:` wrapper is tolerated.
  * @param {unknown} lnurl
  * @returns {boolean}
  */
 export function isLnurl(lnurl) {
-  const lower = norm(lnurl).replace(/^lightning:/, '');
+  const lower = stripWrapperScheme(lnurl).toLowerCase();
   if (!lower) return false;
   return LNURL_PREFIXES.some(prefix => lower.startsWith(prefix));
 }
@@ -171,8 +209,9 @@ export const isValidBitcoinAddress = isBitcoinAddress;
  *                    A unified `bitcoin:?lightning=…` QR has no on-chain
  *                    address, so this returns '' and the caller falls through
  *                    to "not a saveable address".
- *   - `lightning:` — LUD-17 / BOLT11 deep-link scheme. Stripped so the LNURL /
- *                    invoice / Lightning-address predicates see the payload.
+ *   - `lightning:` / `lnurl:` — deep-link wrapper schemes. Stripped so the
+ *                    LNURL / invoice / Lightning-address predicates see the
+ *                    bare payload. (See stripWrapperScheme for the exact rules.)
  *
  * Anything without a recognized scheme (a bare address, an `npub`, a
  * `nostr:` URI) is returned trimmed and otherwise untouched — this function
@@ -200,10 +239,10 @@ export function normalizePaymentAddress(raw) {
     return address.trim();
   }
 
-  // `lightning:` wraps a BOLT11 invoice or an LNURL. The invoice/LNURL
-  // predicates already tolerate the prefix, but stripping it here keeps the
-  // returned value canonical for any downstream consumer.
-  return value.replace(/^lightning:/i, '').trim();
+  // `lightning:` / `lnurl:` wrap a BOLT11 invoice or an LNURL. The predicates
+  // already tolerate these, but stripping here keeps the returned value
+  // canonical for any downstream consumer.
+  return stripWrapperScheme(value);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/utils/lightning.js
+++ b/src/utils/lightning.js
@@ -16,6 +16,7 @@ import {
   isLightningAddress as isLightningAddressShared,
   isLightningInvoice as isLightningInvoiceShared,
   isLnurl as isLnurlShared,
+  stripWrapperScheme,
 } from './addressUtils';
 
 /**
@@ -218,7 +219,7 @@ export class LightningPaymentService {
    */
   async handleLNURL(lnurlInput) {
     try {
-      const cleanLnurl = lnurlInput.replace(/^lightning:/i, '');
+      const cleanLnurl = stripWrapperScheme(lnurlInput);
       const url = this.decodeLNURL(cleanLnurl);
 
       const response = await fetch(url);
@@ -531,7 +532,7 @@ export class LightningPaymentService {
    * @throws {Error} If decoding fails
    */
   decodeLNURL(lnurl) {
-    const clean = lnurl.trim().replace(/^lightning:/i, '');
+    const clean = stripWrapperScheme(lnurl);
 
     // LUD-17: lnurlp://, lnurlw://, lnurlc://, keyauth://
     const lud17Url = resolveLUD17URL(clean);


### PR DESCRIPTION
## What

Scanning a bare LNURL prefixed with `lnurl:` / `LNURL:` (or an uppercase `LIGHTNING:` NFC tag) showed **"Unsupported link format"**. Now those resolve like any other LNURL.

## Why it failed

- **Android** matches NFC/deep-link URI schemes **case-sensitively**, and we only registered lowercase `lightning` / `lnurlw` / `lnurlp` — and no `lnurl` scheme at all. So the tag never cleanly reached the app.
- The **JS** parser and LNURL decoders only stripped `lightning:`, never `lnurl:`.

## Fix

- **AndroidManifest:** register the `lnurl` scheme plus uppercase variants (`LIGHTNING`, `LNURL`, `LNURLP`, `LNURLW`, `BITCOIN`) on the VIEW deep-link and NDEF NFC filters.
- **Shared `stripWrapperScheme()`** in `addressUtils` replaces the scattered `lightning:`-only strips and is wired through every recognition + decode path: send sheet, deep link, NFC, NWC, batch send, auto-withdraw.
- Guards keep LUD-17 (`lnurlw://`) and the `lnurl://host` alias intact; invoice-only strips are left untouched.
- Tests added (real field LNURL, every wrapper case, guards). 18/18 pass.

> Note: the manifest change needs a native rebuild (`npx cap sync android` + new APK) to take effect.

Credits: @AxelHamburch for tracking it down :)