### PR TITLE
Scan LNbits/Fossa ATM QR codes (LNURL fallback links) to withdraw Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buho-app",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "BuhoGo - A Bitcoin Lightning Wallet for the Web",
   "productName": "BuhoGo",
   "author": "pratikpatel <pratikpatelpp802@gmail.com> & drshift <keleeweb@tutanota.com>",

--- a/src-capacitor/android/app/build.gradle
+++ b/src-capacitor/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "mybuho.buhogo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 18
-        versionName "1.8.2"
+        versionCode 19
+        versionName "1.8.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/src-capacitor/package.json
+++ b/src-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buho-app",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "BuhoGo - A Bitcoin Lightning Wallet for the Web",
   "author": "pratikpatel <pratikpatelpp802@gmail.com> & drshift <keleeweb@tutanota.com>",
   "private": true,

--- a/src/components/SendModal.vue
+++ b/src/components/SendModal.vue
@@ -244,7 +244,7 @@ import { createQrScanner } from '../utils/qrScanner';
 import { useAddressBookStore } from '../stores/addressBook';
 import { useWalletStore } from '../stores/wallet';
 import { isSARetailerQR, convertToLightningAddress, getMerchantInfo, SA_RETAIL_SOURCE } from '../utils/merchantQR';
-import { parseBip21, selectBip21Destination } from '../utils/bip21';
+import { parseBip21, selectBip21Destination, extractLnFallbackParam } from '../utils/bip21';
 import {
   isSparkAddress,
   isLightningInvoice,
@@ -338,9 +338,15 @@ export default {
         if (parsed) return 'bip21';
       }
 
-      const cleaned = lower.startsWith('lightning:')
-        ? raw.substring(10).trim()
-        : raw;
+      // http(s) "fallback URL" with the LNURL in a `lightning=` query param
+      // (LNbits / Fossa ATMs) — surface it as LNURL while typing.
+      const lnFallback = extractLnFallbackParam(raw);
+
+      const cleaned = lnFallback
+        ? lnFallback
+        : lower.startsWith('lightning:')
+          ? raw.substring(10).trim()
+          : raw;
 
       if (isSparkAddress(cleaned)) return 'spark';
       if (isLightningInvoice(cleaned)) return 'lightning_invoice';
@@ -721,6 +727,14 @@ export default {
       if (bip21) {
         const destination = selectBip21Destination(bip21);
         return { cleaned: destination ? destination.value : '', bip21 };
+      }
+
+      // http(s) "fallback URL" carrying the LNURL in a `lightning=` query param
+      // (LNbits / Fossa ATMs). Pull out the bare LNURL/invoice so the
+      // recognizers downstream can classify it.
+      const lnFallback = extractLnFallbackParam(trimmed);
+      if (lnFallback) {
+        return { cleaned: lnFallback, bip21: null };
       }
 
       if (trimmed.toLowerCase().startsWith('lightning:')) {

--- a/src/providers/WalletFactory.js
+++ b/src/providers/WalletFactory.js
@@ -9,7 +9,7 @@ import { SparkWalletProvider } from './SparkWalletProvider';
 import { NWCWalletProvider } from './NWCWalletProvider';
 import { LNBitsWalletProvider } from './LNBitsWalletProvider';
 import { WalletProvider } from './WalletProvider';
-import { parseBip21, selectBip21Destination } from '../utils/bip21';
+import { parseBip21, selectBip21Destination, extractLnFallbackParam } from '../utils/bip21';
 import {
   isSparkAddress,
   isLightningInvoice,
@@ -134,6 +134,14 @@ export function parsePaymentDestination(input) {
     cleaned = destination.value;
   } else if (cleaned.toLowerCase().startsWith('lightning:')) {
     cleaned = cleaned.substring(10);
+  } else {
+    // http(s) "fallback URL" with the LNURL/invoice in a `lightning=` query
+    // param (LNbits / Fossa ATMs). Pull it out so the branches below classify
+    // it (LNURL-withdraw in the ATM case); leave non-matching URLs untouched.
+    const lnFallback = extractLnFallbackParam(cleaned);
+    if (lnFallback) {
+      cleaned = lnFallback;
+    }
   }
 
   // Attach BIP21 metadata (amount, label, message, ...) to every result so

--- a/src/stores/autoWithdraw.js
+++ b/src/stores/autoWithdraw.js
@@ -9,7 +9,12 @@ const SPEED_LABELS = { low: 'Economy', medium: 'Standard', high: 'Priority' }
 // fee quote is keyed by slow/medium/fast. Translate at the boundary so
 // Settings UX stays stable while the provider speaks the SDK's language.
 const FEE_SPEED_TO_QUOTE_KEY = { low: 'slow', medium: 'medium', high: 'fast' }
-const COOLDOWN_MS = 60_000 // 60s between triggers per wallet
+const COOLDOWN_MS = 60_000 // 60s between successful triggers per wallet
+// A failed attempt shouldn't hold the wallet hostage for the full 60s success
+// cooldown — transient blips (dropped NWC/Spark connection, LN-address resolve
+// hiccup) deserve a quicker retry. After a failure we roll the cooldown back so
+// the next balance tick can retry once this much time has elapsed.
+const FAILURE_RETRY_MS = 15_000 // 15s backoff before retrying a failed transfer
 const MIN_SEND_SATS = 10   // Don't send dust
 
 // Module-level lock — not in Pinia state, avoids reactivity issues
@@ -109,7 +114,10 @@ export const useAutoWithdrawStore = defineStore('autoWithdraw', {
       if (!threshold || threshold <= 0) return
 
       const balance = Number(balanceSats)
-      if (balance <= threshold) return
+      // Guard non-finite balances explicitly: `NaN <= threshold` is false, so
+      // without this an undefined/garbage balance would slip past the check
+      // below and we'd compute a NaN send amount.
+      if (!Number.isFinite(balance) || balance <= threshold) return
 
       // Lock guard — prevent concurrent execution for same config
       if (_activeWithdrawals.has(configKey)) return
@@ -125,11 +133,17 @@ export const useAutoWithdrawStore = defineStore('autoWithdraw', {
       // Resolve base walletId from composite key (e.g. 'walletId:2' → 'walletId')
       const baseWalletId = configKey.includes(':') ? configKey.split(':').slice(0, -1).join(':') : configKey
 
+      // Declared in the action scope (not inside `try`) so the `catch` block
+      // can report the attempted amount — a `const` inside `try` would be a
+      // ReferenceError in `catch`, which previously masked the real failure
+      // and left the error toast/dialog unshown.
+      let sendAmount = 0
+
       try {
         const wallet = walletStore.wallets.find(w => w.id === baseWalletId)
         if (!wallet) return
 
-        const sendAmount = Math.floor(balance * 0.97)
+        sendAmount = Math.floor(balance * 0.97)
         if (sendAmount < MIN_SEND_SATS) return
 
         const walletType = wallet.type?.toLowerCase() || 'nwc'
@@ -173,6 +187,13 @@ export const useAutoWithdrawStore = defineStore('autoWithdraw', {
         }
       } catch (error) {
         console.error('[Auto-withdraw] Failed:', error.message)
+
+        // The cooldown was set to "now" before the attempt to dam the storm of
+        // balance-refresh ticks. On failure, roll it back so the next tick can
+        // retry after FAILURE_RETRY_MS instead of waiting out the full 60s
+        // success cooldown — the difference between "intermittently works" and
+        // "works on the next refresh".
+        _lastTriggerTime.set(configKey, Date.now() - COOLDOWN_MS + FAILURE_RETRY_MS)
 
         // Hand the raw error to the UI watcher so it can route it
         // through the global payment-error dialog (same surface as
@@ -273,7 +294,14 @@ export const useAutoWithdrawStore = defineStore('autoWithdraw', {
         const result = await provider.payInvoice({ invoice })
         return { id: result.payment_hash || result.id || null, status: 'completed' }
       } else {
-        const nwc = walletStore.connectionStates[walletId]?.nwcInstance
+        // Self-heal a dropped NWC connection (e.g. after an app resume or a
+        // relay disconnect) rather than failing the transfer outright — mirrors
+        // the LNbits ensureLNBitsConnected path above. connectWallet rebuilds
+        // and enables a fresh NWC instance.
+        let nwc = walletStore.connectionStates[walletId]?.nwcInstance
+        if (!nwc) {
+          nwc = await walletStore.connectWallet(walletId)
+        }
         if (!nwc) throw new Error('NWC not connected')
         const result = await nwc.sendPayment(invoice)
         return { id: result.payment_hash || result.paymentHash || result.preimage || null, status: 'completed' }

--- a/src/utils/__tests__/addressUtils.spec.js
+++ b/src/utils/__tests__/addressUtils.spec.js
@@ -117,6 +117,41 @@ test('LUD-17 lnurlp:// passes through untouched and is recognized', () => {
   assert.equal(isLnurl(lud17), true);
 });
 
+// ---------------------------------------------------------------------------
+// normalizePaymentAddress — http(s) LNURL fallback URL (LNbits / Fossa ATMs)
+// ---------------------------------------------------------------------------
+
+const ATM_LNURL =
+  'LNURL1DP68GURN8GHJ7V33D45K7TNNWPSKXEF0VEHHXUMP9ASHQ6F0WCCJ7MRWW4EXCTMX89G9YWPLWQ742VJXWDJYW4NTTQCJ6U6ND9HKX42PG5MX2J3SWA6NZCT02P8NSUMG2YM55D3EW4FHZVNH85CF52CD';
+
+test('http fallback URL: extracts the uppercase LNURL from ?lightning=', () => {
+  const url = `https://21mio.space/fossa/atm?lightning=${ATM_LNURL}`;
+  const bare = normalizePaymentAddress(url);
+  assert.equal(bare, ATM_LNURL);
+  assert.equal(isLnurl(bare), true);
+});
+
+test('http fallback URL: case-insensitive param key, extra params ignored', () => {
+  const url = `https://example.com/atm?foo=bar&LIGHTNING=${ATM_LNURL}&x=1`;
+  assert.equal(normalizePaymentAddress(url), ATM_LNURL);
+});
+
+test('http fallback URL: carries a BOLT11 invoice too', () => {
+  const url = 'https://pay.example.com/x?lightning=lnbc10n1pjxyz';
+  assert.equal(normalizePaymentAddress(url), 'lnbc10n1pjxyz');
+});
+
+test('http fallback URL: no lightning param → left untouched (passthrough)', () => {
+  const url = 'https://example.com/just/a/page?foo=bar';
+  assert.equal(normalizePaymentAddress(url), url);
+});
+
+test('http fallback URL: junk lightning param is not extracted', () => {
+  const url = 'https://example.com/atm?lightning=not-a-lnurl';
+  // Falls through to passthrough — the param isn't a usable destination.
+  assert.equal(normalizePaymentAddress(url), url);
+});
+
 test('passthrough: bare address / npub / nostr URI returned trimmed, untouched', () => {
   assert.equal(normalizePaymentAddress('  alice@example.com  '), 'alice@example.com');
   assert.equal(normalizePaymentAddress('spark1abcdef'), 'spark1abcdef');

--- a/src/utils/addressUtils.js
+++ b/src/utils/addressUtils.js
@@ -23,6 +23,8 @@
  * them as-is, and the regex uses the `/i` flag only for the bech32 arms.
  */
 
+import { extractLnFallbackParam } from './bip21.js';
+
 // ----------------------------------------------------------------------------
 // Constants — exported so other modules can reuse them without re-typing
 // ----------------------------------------------------------------------------
@@ -199,6 +201,12 @@ export function normalizePaymentAddress(raw) {
     }
     return address.trim();
   }
+
+  // http(s) "fallback URL" carrying the LNURL in a `lightning=` query param
+  // (LNbits / Fossa ATMs, Phoenix, WoS, …). Extract the bare LNURL/invoice so
+  // the predicates can classify it; otherwise fall through to passthrough.
+  const lnFallback = extractLnFallbackParam(value);
+  if (lnFallback) return lnFallback;
 
   // `lightning:` wraps a BOLT11 invoice or an LNURL. The invoice/LNURL
   // predicates already tolerate the prefix, but stripping it here keeps the

--- a/src/utils/bip21.js
+++ b/src/utils/bip21.js
@@ -124,3 +124,58 @@ function looksLikeBolt11(value) {
   return lower.startsWith('lnbc') || lower.startsWith('lntb') ||
          lower.startsWith('lntbs') || lower.startsWith('lnbcrt');
 }
+
+/** Cheap shape check for a bech32 LNURL (`lnurl1…`). */
+function looksLikeLnurl(value) {
+  return String(value).toLowerCase().startsWith('lnurl1');
+}
+
+/**
+ * Extract a Lightning destination from an http(s) "fallback URL".
+ *
+ * LNbits / Fossa ATMs (and other LNURL deployments) don't encode a bare LNURL
+ * or a `lightning:` URI in their QR — they encode a regular web page URL with
+ * the LNURL carried in a `lightning` query parameter, e.g.
+ *
+ *   https://21mio.space/fossa/atm?lightning=LNURL1DP68GURN8...
+ *
+ * A phone camera opens the web page; wallets are expected to pull the
+ * `lightning` param and act on it. This is the standard LNURL "fallback URL"
+ * convention, supported by Phoenix, Breez, Wallet of Satoshi, etc.
+ *
+ * We only return the param when it looks like a usable Lightning destination
+ * (bech32 LNURL or a BOLT11 invoice) so a stray `?lightning=` on an unrelated
+ * web URL can't hijack the input. Param key and value matching are both
+ * case-insensitive — ATMs emit uppercase LNURL and the key casing varies.
+ *
+ * @param {unknown} input
+ * @returns {string|null} the bare LNURL / invoice, or null if none present
+ */
+export function extractLnFallbackParam(input) {
+  if (typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  if (!/^https?:\/\//i.test(trimmed)) return null;
+
+  let url;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  // Param keys are case-insensitive per the convention; URLSearchParams keys
+  // are case-sensitive, so scan for any `lightning` key ourselves.
+  let value = null;
+  for (const [key, val] of url.searchParams) {
+    if (key.toLowerCase() === 'lightning' && val) {
+      value = val.trim();
+      break;
+    }
+  }
+  if (!value) return null;
+
+  // Tolerate a nested `lightning:` wrapper inside the param value.
+  value = value.replace(/^lightning:/i, '').trim();
+
+  return looksLikeBolt11(value) || looksLikeLnurl(value) ? value : null;
+}


### PR DESCRIPTION
- Auto Transfer is more reliable: auto-reconnects dropped wallets, retries faster after a hiccup, and no longer fails silently