### PR TITLE
fix(bolt-card): pre-fill withdrawal amount from open invoice

### DIFF
--- a/src/components/PaymentConfirmSheet.vue
+++ b/src/components/PaymentConfirmSheet.vue
@@ -694,6 +694,9 @@ export default {
       if (this.amountMode === 'fixed') {
         this.displayAmount = String(this.fixedSats)
         this.currentCurrency = 'sats'
+      } else if (this.payment?.amount?.defaultAmount) {
+        this.displayAmount = String(this.payment.amount.defaultAmount)
+        this.currentCurrency = 'sats'
       } else {
         this.displayAmount = ''
       }

--- a/src/components/ReceiveModal.vue
+++ b/src/components/ReceiveModal.vue
@@ -689,6 +689,20 @@ export default {
         && !this.generatedInvoice
         && !this.showAmountInput;
     },
+    /**
+     * Public accessor — the sats amount the user currently intends to
+     * receive. The wallet reads this when a withdraw (a Bolt Card or an
+     * LNURL-withdraw voucher) is initiated from this modal, so the redeem
+     * sheet pre-fills the amount instead of opening at 0. A created
+     * specific-amount invoice wins; otherwise the value typed on the keypad.
+     * Returns 0 when neither applies (a default amountless invoice, or an
+     * untouched keypad), which the caller reads as "nothing to carry".
+     */
+    intendedReceiveSats() {
+      if (this.generatedInvoice?.amount > 0) return this.generatedInvoice.amount;
+      if (this.showAmountKeypadView && this.amountInSats > 0) return this.amountInSats;
+      return 0;
+    },
     paymentStatusClass() {
       switch (this.paymentStatus) {
         case PaymentStatus.CONFIRMED:

--- a/src/pages/Wallet.vue
+++ b/src/pages/Wallet.vue
@@ -874,6 +874,11 @@ export default {
       // built by the corresponding `*SheetProps` computed below.
       showSendSheet: false,
       showWithdrawSheet: false,
+      // Set when a withdraw is initiated from the Receive modal's "Redeem"
+      // button, which closes the modal before the scan happens. Carried into
+      // the redeem sheet by onPaymentDetected (then cleared), so the amount
+      // the user already entered survives the modal handoff.
+      pendingWithdrawTargetSats: null,
       // Bitcoin on-chain runs through L1BitcoinWithdraw, which owns its
       // own bottom-sheet and bundles fee-priority selection + the
       // dust/balance checks the LN paths don't need.
@@ -1680,6 +1685,17 @@ export default {
         this.updateSecondaryValue();
       },
       immediate: true
+    },
+
+    /**
+     * The Receive modal's "Redeem" button stashes the user's intended amount
+     * in `pendingWithdrawTargetSats` and opens this scanner so the redeem
+     * sheet can pre-fill it once the withdraw QR is scanned. If the scanner
+     * is dismissed without a scan, drop the stash so it can't pre-fill a
+     * later, unrelated withdraw.
+     */
+    showSendModal(open) {
+      if (!open) this.pendingWithdrawTargetSats = null;
     },
 
     /**
@@ -3390,6 +3406,11 @@ export default {
     },
 
     handleScanWithdraw() {
+      // Carry whatever amount the user already set — a created invoice or the
+      // value typed on the keypad — into the redeem scan, mirroring the
+      // NFC-tap path. The modal closes here, so stash it for onPaymentDetected
+      // to read after the withdraw QR is scanned.
+      this.pendingWithdrawTargetSats = this.$refs.receiveModal?.intendedReceiveSats || null;
       this.showReceiveModal = false;
       this.$nextTick(() => {
         this.showSendModal = true;
@@ -4018,6 +4039,13 @@ export default {
       let resolved = true;   // assume we'll reach a confirm sheet / handoff
       if (fromField) { this.sendResolving = true; this.sendResolveError = ''; }
 
+      // Consume any amount stashed by the Receive modal's "Redeem" button
+      // (which closes the modal before this scan, so it can't be read live
+      // below). Cleared unconditionally so a stale value can never leak into
+      // an unrelated withdraw.
+      const deferredWithdrawTargetSats = this.pendingWithdrawTargetSats;
+      this.pendingWithdrawTargetSats = null;
+
       try {
         // Transform the payment data to match expected structure
         if (paymentData.type === 'lightning_invoice' && paymentData.data) {
@@ -4059,13 +4087,19 @@ export default {
             // LNURL-withdraw: set up withdraw flow
             this.resetWithdrawState();
 
-            // If the Receive modal is open with a specific invoice amount, capture
-            // it so the withdrawal sheet can pre-fill the field instead of showing 0.
-            const invoiceAmount = (this.showReceiveModal &&
-              this.$refs.receiveModal?.generatedInvoice?.amount > 0)
-              ? this.$refs.receiveModal.generatedInvoice.amount
-              : null;
-            if (invoiceAmount !== null) this.showReceiveModal = false;
+            // Pre-fill the redeem sheet with the amount the user intended to
+            // receive, instead of opening at 0. Two sources feed this:
+            //   - live: the Receive modal is still open (NFC tap or paste while
+            //     viewing it) — read its current intended amount directly.
+            //   - deferred: the user tapped "Redeem", which closed the modal
+            //     before this scan — handleScanWithdraw stashed the amount.
+            // Either way, close the modal so the redeem sheet never stacks on
+            // top of it.
+            let receiveAmount = deferredWithdrawTargetSats;
+            if (this.showReceiveModal) {
+              receiveAmount = this.$refs.receiveModal?.intendedReceiveSats || null;
+              this.showReceiveModal = false;
+            }
 
             this.pendingPayment = {
               ...paymentData,
@@ -4074,7 +4108,7 @@ export default {
               ...lnurlInfo,
               amount: lnurlInfo.fixedAmountSats || 0,
               description: lnurlInfo.defaultDescription,
-              receiveAmount: invoiceAmount
+              receiveAmount
             };
           } else {
             // LNURL-pay: existing flow

--- a/src/pages/Wallet.vue
+++ b/src/pages/Wallet.vue
@@ -1479,7 +1479,17 @@ export default {
       if (p.isFixedAmount) {
         amount = { mode: 'fixed', fixedSats: p.fixedAmountSats };
       } else if (p.minSats && p.maxSats && p.minSats !== p.maxSats) {
-        amount = { mode: 'range', minSats: p.minSats, maxSats: p.maxSats };
+        const defaultAmount = (p.receiveAmount
+          && p.receiveAmount >= p.minSats
+          && p.receiveAmount <= p.maxSats)
+          ? p.receiveAmount
+          : null;
+        amount = {
+          mode: 'range',
+          minSats: p.minSats,
+          maxSats: p.maxSats,
+          ...(defaultAmount ? { defaultAmount } : {})
+        };
       } else {
         // Defensive — every spec-compliant withdraw QR carries a range
         // or a fixed amount, but if metadata is missing fall back to a
@@ -4048,13 +4058,23 @@ export default {
           if (lnurlInfo.lnurlType === 'withdrawRequest') {
             // LNURL-withdraw: set up withdraw flow
             this.resetWithdrawState();
+
+            // If the Receive modal is open with a specific invoice amount, capture
+            // it so the withdrawal sheet can pre-fill the field instead of showing 0.
+            const invoiceAmount = (this.showReceiveModal &&
+              this.$refs.receiveModal?.generatedInvoice?.amount > 0)
+              ? this.$refs.receiveModal.generatedInvoice.amount
+              : null;
+            if (invoiceAmount !== null) this.showReceiveModal = false;
+
             this.pendingPayment = {
               ...paymentData,
               type: 'lnurl_withdraw',
               lnurl: paymentData.data,
               ...lnurlInfo,
               amount: lnurlInfo.fixedAmountSats || 0,
-              description: lnurlInfo.defaultDescription
+              description: lnurlInfo.defaultDescription,
+              receiveAmount: invoiceAmount
             };
           } else {
             // LNURL-pay: existing flow


### PR DESCRIPTION
## Problem

When a user creates a Lightning invoice in the Receive modal (with a specific amount, e.g. 1 500 sats) and then taps a Bolt Card, the app correctly opens the Bolt Card withdrawal screen — but it shows **0 SATS (min X / max Y)** instead of pre-filling the invoice amount. The user has to type the amount manually, breaking the expected flow.

Additionally, the Receive modal stayed open underneath the withdrawal sheet, causing the two screens to compete visually.

## Root Cause

Three gaps in the existing code:

1. **`onPaymentDetected()` in `Wallet.vue`** — when a `withdrawRequest` LNURL is detected, `pendingPayment.amount` is set to `fixedAmountSats || 0`, completely discarding any invoice amount displayed in the open Receive modal. The Receive modal was also never explicitly closed.

2. **`withdrawSheetProps` in `Wallet.vue`** — for `mode: 'range'` withdrawals, no `defaultAmount` was passed to the sheet, so the amount input started empty.

3. **`resetForFreshOpen()` in `PaymentConfirmSheet.vue`** — only handled `fixed` mode pre-fill; `range` and `free` modes always reset the input to an empty string.

## Fix

Three targeted changes, no new abstractions:

**`src/pages/Wallet.vue` — `onPaymentDetected()`**  
Before building `pendingPayment`, check whether the Receive modal is open with an invoice amount > 0. If so, close the Receive modal and carry the amount forward as `receiveAmount` on the payment object.

**`src/pages/Wallet.vue` — `withdrawSheetProps`**  
When building the `range` amount descriptor, check if `receiveAmount` falls within `[minSats, maxSats]`. If it does, add `defaultAmount` to the object so the sheet knows what to pre-fill.

**`src/components/PaymentConfirmSheet.vue` — `resetForFreshOpen()`**  
Added an `else if` branch: if `payment.amount.defaultAmount` is set, pre-fill `displayAmount` with that value (in sats) instead of leaving the field empty.

## Edge Cases Covered

| Scenario | Behaviour |
|---|---|
| Invoice amount within Bolt Card range | Amount pre-filled, Receive modal closed |
| Invoice amount outside Bolt Card range | Normal empty input, no crash |
| Bolt Card with fixed amount | Unchanged — handled by existing fixed-mode branch |
| Receive modal open with zero-amount invoice | No pre-fill, no modal close |
| NFC tap without Receive modal open | Unchanged behaviour |

## Test Plan

- [ ] Create a specific-amount invoice (e.g. 1 000 sats) in the Receive modal
- [ ] Tap a Bolt Card whose range covers that amount — withdrawal sheet opens with 1 000 sats pre-filled, Receive modal is gone
- [ ] Tap a Bolt Card whose range does not cover the amount — withdrawal sheet opens with empty input (range shown as usual)
- [ ] Tap a Bolt Card without the Receive modal open — normal withdrawal flow, unaffected
- [ ] Tap a fixed-amount Bolt Card — fixed amount shown as before
