### PR TITLE
Contact avatars: one silhouette system, color picker removed

### DIFF
--- a/src/components/AddressBook/AddressBookEntry.vue
+++ b/src/components/AddressBook/AddressBookEntry.vue
@@ -4,15 +4,11 @@
     :class="$q.dark.isActive ? 'contact-card-dark' : 'contact-card-light'"
     @click="$emit('pay', entry)"
   >
-    <!-- Avatar — real picture for nostr-sourced contacts, colored
-         initial otherwise. The change-color emit still fires on the
-         circle either way; for nostr contacts it's a no-op-friendly
-         click target (color picker just won't show a visible ring
-         under the photo). -->
+    <!-- Avatar — real picture for nostr-sourced contacts, the
+         app-wide monoline silhouette otherwise. -->
     <ContactAvatar
       class="contact-avatar"
       :entry="entry"
-      @click.stop="$emit('change-color', entry)"
     />
 
     <!-- Entry Details -->
@@ -142,7 +138,7 @@ export default {
       required: true
     }
   },
-  emits: ['edit', 'delete', 'change-color', 'pay', 'toggle-favorite', 'copy-address'],
+  emits: ['edit', 'delete', 'pay', 'toggle-favorite', 'copy-address'],
   computed: {
     addressType() {
       return this.entry.addressType || 'lightning'

--- a/src/components/AddressBook/AddressBookList.vue
+++ b/src/components/AddressBook/AddressBookList.vue
@@ -53,7 +53,6 @@
               :entry="entry"
               @edit="editEntry"
               @delete="confirmDeleteEntry"
-              @change-color="changeEntryColor"
               @pay="payContact"
               @toggle-favorite="toggleFavorite"
               @copy-address="copyAddress"
@@ -75,7 +74,6 @@
               :entry="entry"
               @edit="editEntry"
               @delete="confirmDeleteEntry"
-              @change-color="changeEntryColor"
               @pay="payContact"
               @toggle-favorite="toggleFavorite"
               @copy-address="copyAddress"
@@ -127,33 +125,6 @@
       </q-btn>
     </div>
 
-    <!-- Color Picker Dialog -->
-    <q-dialog v-model="showColorPicker">
-      <q-card class="color-picker-card" :class="$q.dark.isActive ? 'card_dark_style' : 'card_light_style'">
-        <q-card-section>
-          <div class="color-picker-title" :class="$q.dark.isActive ? 'dialog_title_dark' : 'dialog_title_light'">
-            {{ $t('Choose Color for {name}', { name: selectedEntry?.name || '' }) }}
-          </div>
-        </q-card-section>
-
-        <q-card-section class="color-grid">
-          <div
-            v-for="color in colorPalette"
-            :key="color"
-            class="color-option"
-            :class="{ 'selected': selectedEntry?.color === color }"
-            :style="{ backgroundColor: color }"
-            @click="updateEntryColor(color)"
-          >
-            <Icon
-              v-if="selectedEntry?.color === color"
-              icon="tabler:check"
-              class="color-check"
-            />
-          </div>
-        </q-card-section>
-      </q-card>
-    </q-dialog>
 
     <!-- Delete Confirmation Dialog -->
     <q-dialog v-model="showDeleteDialog" :class="$q.dark.isActive ? 'dialog_dark' : 'dialog_light'">
@@ -236,7 +207,6 @@ export default {
   emits: ['add-contact', 'edit-contact', 'pay-contact'],
   data() {
     return {
-      showColorPicker: false,
       selectedEntry: null,
       showDeleteDialog: false,
       entryToDelete: null,
@@ -247,8 +217,7 @@ export default {
     ...mapState(useAddressBookStore, [
       'entries',
       'filteredEntries',
-      'searchQuery',
-      'colorPalette'
+      'searchQuery'
     ]),
 
     filteredFavorites() {
@@ -324,32 +293,6 @@ export default {
       }
     },
 
-    changeEntryColor(entry) {
-      this.selectedEntry = entry
-      this.showColorPicker = true
-    },
-
-    async updateEntryColor(color) {
-      if (!this.selectedEntry) return
-
-      try {
-        await this.updateEntry(this.selectedEntry.id, { color })
-        this.showColorPicker = false
-        this.selectedEntry = null
-
-        this.$q.notify({
-          type: 'positive',
-          message: this.$t('Color updated'),
-
-        })
-      } catch (error) {
-        this.$q.notify({
-          type: 'negative',
-          message: this.$t('Couldn\'t update color'),
-
-        })
-      }
-    },
 
     showClearAllDialog() {
       this.showClearAllConfirmDialog = true
@@ -605,68 +548,11 @@ export default {
     max-width: 240px;
   }
 
-  .color-grid {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 0.75rem;
-  }
-
-  .color-option {
-    width: 40px;
-    height: 40px;
-  }
-
   .section-header {
     padding: 10px 12px 6px;
   }
 }
 
-/* Color Picker */
-.color-picker-card {
-  width: 100%;
-  max-width: 320px;
-  border-radius: 16px;
-}
-
-.color-picker-title {
-  font-family: 'Manrope', sans-serif;
-  font-size: 16px;
-  text-align: center;
-}
-
-.color-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1rem;
-  padding: 1rem;
-}
-
-.color-option {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-}
-
-.color-option:hover {
-  transform: scale(1.1);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
-}
-
-.color-option.selected {
-  transform: scale(1.1);
-  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.3);
-}
-
-.color-check {
-  color: white;
-  font-size: 20px;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
-}
 
 /* Delete / Clear-All Confirmation Dialog
    Surface language: rounded card (--radius-xl), layered shadow, generous

--- a/src/components/AddressBook/AddressBookModal.vue
+++ b/src/components/AddressBook/AddressBookModal.vue
@@ -71,16 +71,15 @@
 
         <!-- MANUAL — also used for the edit flow -->
         <template v-else>
+          <!-- Static preview: the app-wide filled-bust silhouette.
+               Contacts no longer carry a color; a Nostr picture (via
+               the Search / Scan tabs) is the only way an avatar
+               personalizes. -->
           <div class="avatar-preview">
-            <div
-              class="preview-circle"
-              :style="{ backgroundColor: formData.color }"
-              @click="showColorPicker = true"
-            >
-              <span class="preview-initial">{{ getPreviewInitial() }}</span>
-              <div class="preview-edit-dot">
-                <Icon icon="tabler:palette" width="12" height="12" />
-              </div>
+            <div class="preview-circle">
+              <svg class="preview-glyph" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 12.3a4.05 4.05 0 1 0 0-8.1 4.05 4.05 0 0 0 0 8.1Zm0 2.2c-4.3 0-7.6 2.6-8.1 6.3h16.2c-.5-3.7-3.8-6.3-8.1-6.3Z" />
+              </svg>
             </div>
           </div>
 
@@ -194,33 +193,6 @@
       </q-card-actions>
     </q-card>
 
-    <!-- Color Picker Dialog -->
-    <q-dialog v-model="showColorPicker">
-      <q-card class="color-picker-card" :class="$q.dark.isActive ? 'card_dark_style' : 'card_light_style'">
-        <q-card-section>
-          <div class="color-picker-title" :class="$q.dark.isActive ? 'dialog_title_dark' : 'dialog_title_light'">
-            {{ $t('Choose Color') }}
-          </div>
-        </q-card-section>
-
-        <q-card-section class="color-grid">
-          <div
-            v-for="color in colorPalette"
-            :key="color"
-            class="color-option"
-            :class="{ 'selected': formData.color === color }"
-            :style="{ backgroundColor: color }"
-            @click="selectColor(color)"
-          >
-            <Icon
-              v-if="formData.color === color"
-              icon="tabler:check"
-              class="color-check"
-            />
-          </div>
-        </q-card-section>
-      </q-card>
-    </q-dialog>
   </q-dialog>
 </template>
 
@@ -297,15 +269,12 @@ export default {
       formData: {
         name: '',
         address: '',
-        color: '#3B82F6',
         notes: ''
       },
       isSaving: false,
-      showColorPicker: false
     }
   },
   computed: {
-    ...mapState(useAddressBookStore, ['colorPalette']),
 
     show: {
       get() {
@@ -389,7 +358,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions(useAddressBookStore, ['addEntry', 'updateEntry', 'getRandomColor']),
+    ...mapActions(useAddressBookStore, ['addEntry', 'updateEntry']),
 
     switchTab(id) {
       if (this.activeTab === id) return
@@ -405,14 +374,12 @@ export default {
         this.formData = {
           name: this.entry.name,
           address: this.entry.address || this.entry.lightningAddress || '',
-          color: this.entry.color,
           notes: this.entry.notes || ''
         }
       } else {
         this.formData = {
           name: '',
           address: '',
-          color: this.getRandomColor(),
           notes: ''
         }
       }
@@ -422,22 +389,12 @@ export default {
       this.formData = {
         name: '',
         address: '',
-        color: '#3B82F6',
         notes: ''
       }
       this.isSaving = false
-      this.showColorPicker = false
       this.activeTab = 'manual'
     },
 
-    getPreviewInitial() {
-      return this.formData.name ? this.formData.name.charAt(0).toUpperCase() : '?'
-    },
-
-    selectColor(color) {
-      this.formData.color = color
-      this.showColorPicker = false
-    },
 
     /**
      * Child save callback — fires after AddContactSearch or
@@ -481,7 +438,6 @@ export default {
           name: this.formData.name.trim(),
           address: this.formData.address.trim(),
           addressType: this.detectedType,
-          color: this.formData.color,
           notes: this.formData.notes?.trim() || ''
         }
 
@@ -638,51 +594,32 @@ export default {
   margin-bottom: 1.25rem;
 }
 
+/* Silhouette preview — same blue-on-pale-blue treatment as
+   ContactAvatar's fallback, purely informational (no picker behind
+   it anymore). */
 .preview-circle {
-  position: relative;
   width: 64px;
   height: 64px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  background: #EAEFF7;
+  color: #3B82F6;
 }
 
-.preview-circle:hover {
-  transform: scale(1.04);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22);
+.body--dark .preview-circle {
+  background: #23272E;
+  color: #5B8DEF;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
-.preview-initial {
-  color: white;
-  font-family: 'Manrope', sans-serif;
-  font-size: 26px;
-  font-weight: 700;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-}
-
-.preview-edit-dot {
-  position: absolute;
-  bottom: -2px;
-  right: -2px;
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  background: var(--bg-card, #fff);
-  color: var(--text-primary);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
-  border: 1px solid var(--border-card);
-}
-
-.body--light .preview-edit-dot {
-  background: #fff;
-  color: #374151;
+.preview-glyph {
+  /* Filled marks read smaller than strokes — 52% matches the
+     reference wallet's bust-to-disc ratio. */
+  width: 52%;
+  height: 52%;
+  display: block;
 }
 
 /* Form */
@@ -883,53 +820,6 @@ export default {
   opacity: 0.4;
 }
 
-/* Color Picker */
-.color-picker-card {
-  width: 100%;
-  max-width: 320px;
-  border-radius: var(--radius-md);
-}
-
-.color-picker-title {
-  font-family: 'Manrope', sans-serif;
-  font-size: 18px;
-  text-align: center;
-}
-
-.color-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1rem;
-  padding: 1rem;
-}
-
-.color-option {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-}
-
-.color-option:hover {
-  transform: scale(1.1);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
-}
-
-.color-option.selected {
-  transform: scale(1.1);
-  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.3);
-}
-
-.color-check {
-  color: white;
-  font-size: 20px;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
-}
 
 /* Responsive Design */
 @media (max-width: 480px) {
@@ -955,14 +845,5 @@ export default {
     padding: 0.75rem 1.25rem 1.25rem;
   }
 
-  .color-grid {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 0.75rem;
-  }
-
-  .color-option {
-    width: 40px;
-    height: 40px;
-  }
 }
 </style>

--- a/src/components/AddressBook/ContactAvatar.vue
+++ b/src/components/AddressBook/ContactAvatar.vue
@@ -1,8 +1,7 @@
 <template>
   <span
     class="contact-avatar"
-    :class="{ 'contact-avatar--has-image': visibleAvatarUrl }"
-    :style="!visibleAvatarUrl ? { background: backgroundColor } : null"
+    :class="visibleAvatarUrl ? 'contact-avatar--has-image' : 'contact-avatar--fallback'"
   >
     <img
       v-if="visibleAvatarUrl"
@@ -11,7 +10,20 @@
       :alt="''"
       @error="onImgError"
     />
-    <span v-else class="contact-avatar__initial">{{ initial }}</span>
+    <!-- No picture: the filled-bust silhouette (the reference wallet's
+         treatment, adopted 1:1) — solid blue figure on a pale blue-
+         tinted disc, both themes. One mark for everyone, no initials,
+         no per-contact color. The glyph scales with whatever size the
+         parent sets, so every surface keeps its rhythm. -->
+    <svg
+      v-else
+      class="contact-avatar__glyph"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 12.3a4.05 4.05 0 1 0 0-8.1 4.05 4.05 0 0 0 0 8.1Zm0 2.2c-4.3 0-7.6 2.6-8.1 6.3h16.2c-.5-3.7-3.8-6.3-8.1-6.3Z" />
+    </svg>
   </span>
 </template>
 
@@ -20,8 +32,10 @@
  * Unified contact avatar.
  *
  * Renders a Nostr-sourced profile picture when one is available,
- * otherwise falls back to the colored-initial circle every part of
- * the app already shows for manual contacts.
+ * otherwise falls back to the filled-bust silhouette — one mark for
+ * every picture-less contact, blue on a pale blue-tinted disc in both
+ * themes (the reference wallet's treatment, adopted 1:1). The old
+ * colored-initial circles are retired (design decision 2026-07-25).
  *
  * Layout is intentionally *not* owned by this component — the parent
  * supplies width / height / font-size through its own class so each
@@ -33,19 +47,16 @@
  *   3. graceful fallback when the image fails to load
  *
  * `entry` is intentionally permissive — full address-book entry, a
- * lightweight payment-recipient adapter, or just `{ name, color }`
- * all work. `picture` / `name` / `color` explicit overrides win when
- * supplied so callers can render in-flight resolved profiles before
- * a store entry exists yet.
+ * lightweight payment-recipient adapter, or just `{ name }` all work.
+ * `picture` explicit override wins when supplied so callers can
+ * render in-flight resolved profiles before a store entry exists yet.
  *
- * `initialLength` defaults to 1 char, matching the existing
- * AddressBookEntry pattern. Set to `2` for the transaction-row look
- * which uses `name.substring(0, 2)`.
+ * `name` / `color` / `initialLength` remain declared so existing call
+ * sites keep working, but the silhouette fallback ignores them — the
+ * per-contact color field is legacy data now.
  */
 
 import { matchLnAddressService } from '../../services/lnAddressServices'
-
-const DEFAULT_FALLBACK_COLOR = '#3B82F6'
 
 export default {
   name: 'ContactAvatar',
@@ -100,21 +111,6 @@ export default {
       return svc?.logo || ''
     },
 
-    initial() {
-      const candidate = (this.name || this.entry?.name || '').trim()
-      if (!candidate) return '?'
-      if (this.initialLength === 2) {
-        const cleaned = candidate.replace(/[^\p{L}\p{N}\s]/gu, '').trim()
-        const chars = cleaned.slice(0, 2)
-        return chars ? chars.toUpperCase() : '?'
-      }
-      const ch = candidate.replace(/[^\p{L}\p{N}]/u, '').charAt(0)
-      return (ch || '?').toUpperCase()
-    },
-
-    backgroundColor() {
-      return this.color || this.entry?.color || DEFAULT_FALLBACK_COLOR
-    },
   },
 
   watch: {
@@ -158,7 +154,25 @@ export default {
   display: block;
 }
 
-.contact-avatar__initial {
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+/* Silhouette fallback — the reference wallet's look, copied 1:1:
+   solid blue bust on a pale blue-tinted disc. Dark mode keeps the
+   same blue (slightly lifted for contrast) on a cool dark disc. */
+.contact-avatar--fallback {
+  background: #EAEFF7;
+  color: #3B82F6;
+}
+
+.body--dark .contact-avatar--fallback {
+  background: #23272E;
+  color: #5B8DEF;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.contact-avatar__glyph {
+  /* Filled marks read smaller than strokes — 52% matches the
+     reference wallet's bust-to-disc ratio. */
+  width: 52%;
+  height: 52%;
+  display: block;
 }
 </style>

--- a/src/components/PaymentConfirmSheet.vue
+++ b/src/components/PaymentConfirmSheet.vue
@@ -56,10 +56,13 @@
           <section class="recipient">
             <div
               class="recipient-avatar"
-              :class="{ 'has-logo': showRecipientLogo }"
+              :class="{
+                'has-logo': showRecipientLogo,
+                'recipient-avatar--silhouette': isSilhouetteRecipient
+              }"
               :style="showRecipientLogo
                 ? (recipientLogoBg ? { background: recipientLogoBg } : null)
-                : { background: recipientColor }"
+                : (isSilhouetteRecipient ? null : { background: recipientColor })"
             >
               <img
                 v-if="showRecipientLogo"
@@ -69,6 +72,17 @@
                 :class="{ 'recipient-logo--contain': recipientLogoContain }"
                 @error="logoFailed = true"
               />
+              <!-- Picture-less contact: the app-wide filled-bust
+                   silhouette, never a colored initial. -->
+              <svg
+                v-else-if="isSilhouetteRecipient"
+                class="recipient-glyph"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M12 12.3a4.05 4.05 0 1 0 0-8.1 4.05 4.05 0 0 0 0 8.1Zm0 2.2c-4.3 0-7.6 2.6-8.1 6.3h16.2c-.5-3.7-3.8-6.3-8.1-6.3Z" />
+              </svg>
               <span v-else>{{ recipientInitial }}</span>
             </div>
             <div class="recipient-meta">
@@ -422,6 +436,12 @@ export default {
     // payment, so the badge simply never renders in the common case.
     recipientVerification() {
       return this.payment?.recipient?.verification || null
+    },
+
+    // Picture-less matched contact → the app-wide silhouette mark. A
+    // loaded logo (photo / brand / Branta) always wins over it.
+    isSilhouetteRecipient() {
+      return !!this.payment?.recipient?.silhouette && !this.showRecipientLogo
     },
 
     // Fiat-payout service context (Tando, Bitzed, …), attached by the
@@ -1061,6 +1081,30 @@ export default {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
   flex-shrink: 0;
   overflow: hidden;
+}
+
+/* Silhouette hero — same blue-on-pale-blue treatment as ContactAvatar
+   (the reference wallet's look, copied 1:1), so the confirm sheet and
+   every list agree. */
+.recipient-avatar--silhouette {
+  background: #EAEFF7;
+  color: #3B82F6;
+  text-shadow: none;
+  box-shadow: none;
+}
+
+.body--dark .recipient-avatar--silhouette {
+  background: #23272E;
+  color: #5B8DEF;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.recipient-glyph {
+  /* Filled marks read smaller than strokes — 52% matches the
+     reference wallet's bust-to-disc ratio. */
+  width: 52%;
+  height: 52%;
+  display: block;
 }
 .recipient-avatar.has-logo { background: #fff; box-shadow: inset 0 0 0 1px var(--border-card); }
 .recipient-logo { width: 100%; height: 100%; object-fit: cover; }

--- a/src/pages/Wallet.vue
+++ b/src/pages/Wallet.vue
@@ -2263,6 +2263,10 @@ export default {
         name: contact.name || fallback.fallbackName,
         color: contact.color || fallback.fallbackColor,
         logoUrl: safeLogoUrl,
+        // Matched contact without a picture: the sheet renders the monoline
+        // silhouette (same mark ContactAvatar shows everywhere else) — the
+        // colored-initial circles are retired.
+        silhouette: !safeLogoUrl,
         addressType: fallback.addressType,
         address: fallback.address,
         matchedContact: true,


### PR DESCRIPTION
## Summary

dev already carries the send-flow unification via #211 (a snapshot of the same work). After rebasing onto dev, this PR is the remaining phase: the contact avatar system.

## What changed

- ContactAvatar: contacts without a picture render one filled-bust silhouette (blue on a pale blue-tinted disc, both themes) instead of a random colored initial. Nostr photos and payout-provider brand logos still win. Per-contact colors are retired; the `name` / `color` / `initialLength` props stay declared so call sites keep working, and stored color values remain as inert legacy data (fully reversible, no migration).
- Color picker removed everywhere: the Address Book list dialog, the add/edit modal dialog, the tappable avatar preview (now a static silhouette), and the contact form no longer writes a color.
- PaymentConfirmSheet: matched contacts without a picture get the same silhouette hero (`recipientFromContact` flags them); the colored-initial circle is gone from the confirm sheet as well.

## Testing

- Browser-verified in both themes across the Send sheet contact list, batch picker, quick contacts, address book, and the confirm-sheet hero; brand logos (Tando), Nostr photos, dim/unpayable states, and rail dots all compose correctly with the new mark.
- Full unit suite and production build green.

## Merge order

#212 → #213 → #214 (each stacked on the previous).
