### PR TITLE
chore(release): bump to 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "buho-app",
-  "version": "1.8.4",
-  "description": "BuhoGo - A Bitcoin Lightning Wallet for the Web",
+  "version": "1.9.0",
+  "description": "BuhoGO: the friendly self-custodial Bitcoin and Lightning wallet. Spark, Arkade, LNbits, and Nostr Wallet Connect in one app, on Android and the web.",
   "productName": "BuhoGo",
   "author": "pratikpatel <pratikpatelpp802@gmail.com> & drshift <keleeweb@tutanota.com>",
   "type": "module",

--- a/src-capacitor/android/app/build.gradle
+++ b/src-capacitor/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "mybuho.buhogo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 20
-        versionName "1.8.4"
+        versionCode 21
+        versionName "1.9.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/src-capacitor/ios/App/App.xcodeproj/project.pbxproj
+++ b/src-capacitor/ios/App/App.xcodeproj/project.pbxproj
@@ -348,11 +348,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.9.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = de.mybuho.buhogo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -368,11 +368,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = de.mybuho.buhogo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/src-capacitor/package.json
+++ b/src-capacitor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "buho-app",
-  "version": "1.8.4",
-  "description": "BuhoGo - A Bitcoin Lightning Wallet for the Web",
+  "version": "1.9.0",
+  "description": "BuhoGO: the friendly self-custodial Bitcoin and Lightning wallet. Spark, Arkade, LNbits, and Nostr Wallet Connect in one app, on Android and the web.",
   "author": "pratikpatel <pratikpatelpp802@gmail.com> & drshift <keleeweb@tutanota.com>",
   "private": true,
   "dependencies": {

--- a/update-version.sh
+++ b/update-version.sh
@@ -16,23 +16,29 @@ fi
 echo "Updating version to $NEW_VERSION..."
 
 PACKAGE_JSON="package.json"
+CAPACITOR_PACKAGE_JSON="src-capacitor/package.json"
 BUILD_GRADLE="src-capacitor/android/app/build.gradle"
+IOS_PROJECT="src-capacitor/ios/App/App.xcodeproj/project.pbxproj"
+ZAPSTORE_YAML="zapstore.yaml"
 
-if [ ! -f "$PACKAGE_JSON" ]; then
-    echo "Error: $PACKAGE_JSON not found"
-    exit 1
-fi
+# Underscored form for the APK filename Zapstore points at (1.9.0 -> 1_9_0)
+UNDERSCORE_VERSION="${NEW_VERSION//./_}"
 
-if [ ! -f "$BUILD_GRADLE" ]; then
-    echo "Error: $BUILD_GRADLE not found"
-    exit 1
-fi
+for required in "$PACKAGE_JSON" "$CAPACITOR_PACKAGE_JSON" "$BUILD_GRADLE"; do
+    if [ ! -f "$required" ]; then
+        echo "Error: $required not found"
+        exit 1
+    fi
+done
 
 CURRENT_VERSION=$(grep -o '"version": "[^"]*"' "$PACKAGE_JSON" | cut -d'"' -f4)
 echo "Current version: $CURRENT_VERSION"
 
 sed -i.bak "s/\"version\": \"[^\"]*\"/\"version\": \"$NEW_VERSION\"/" "$PACKAGE_JSON"
 echo "✓ Updated $PACKAGE_JSON"
+
+sed -i.bak "s/\"version\": \"[^\"]*\"/\"version\": \"$NEW_VERSION\"/" "$CAPACITOR_PACKAGE_JSON"
+echo "✓ Updated $CAPACITOR_PACKAGE_JSON"
 
 CURRENT_VERSION_CODE=$(grep -o 'versionCode [0-9]*' "$BUILD_GRADLE" | grep -o '[0-9]*')
 NEW_VERSION_CODE=$((CURRENT_VERSION_CODE + 1))
@@ -43,8 +49,34 @@ echo "✓ Updated $BUILD_GRADLE"
 echo "  - versionCode: $CURRENT_VERSION_CODE → $NEW_VERSION_CODE"
 echo "  - versionName: $NEW_VERSION"
 
-rm -f "$PACKAGE_JSON.bak" "$BUILD_GRADLE.bak"
+# iOS carries the same pair under different names. Kept level with the
+# Android versionCode so a build number means the same thing on both.
+if [ -f "$IOS_PROJECT" ]; then
+    sed -i.bak "s/MARKETING_VERSION = [^;]*;/MARKETING_VERSION = $NEW_VERSION;/" "$IOS_PROJECT"
+    sed -i.bak "s/CURRENT_PROJECT_VERSION = [0-9]*;/CURRENT_PROJECT_VERSION = $NEW_VERSION_CODE;/" "$IOS_PROJECT"
+    rm -f "$IOS_PROJECT.bak"
+    echo "✓ Updated $IOS_PROJECT"
+    echo "  - MARKETING_VERSION: $NEW_VERSION"
+    echo "  - CURRENT_PROJECT_VERSION: $NEW_VERSION_CODE"
+else
+    echo "- Skipped iOS project (not present)"
+fi
+
+# Zapstore reads the id and version out of the APK, so only the filename
+# it points at (and the note documenting it) need bumping here.
+if [ -f "$ZAPSTORE_YAML" ]; then
+    sed -i.bak "s/version ([0-9][0-9.]*)/version ($NEW_VERSION)/" "$ZAPSTORE_YAML"
+    sed -i.bak "s|release_source: ./output/BuhoGO_v[0-9_]*\.apk|release_source: ./output/BuhoGO_v$UNDERSCORE_VERSION.apk|" "$ZAPSTORE_YAML"
+    rm -f "$ZAPSTORE_YAML.bak"
+    echo "✓ Updated $ZAPSTORE_YAML"
+    echo "  - release_source: ./output/BuhoGO_v$UNDERSCORE_VERSION.apk"
+else
+    echo "- Skipped $ZAPSTORE_YAML (not present)"
+fi
+
+rm -f "$PACKAGE_JSON.bak" "$CAPACITOR_PACKAGE_JSON.bak" "$BUILD_GRADLE.bak"
 
 echo ""
 echo "Version update complete!"
 echo "New version: $NEW_VERSION (versionCode: $NEW_VERSION_CODE)"
+echo "Remember: the APK at ./output/BuhoGO_v$UNDERSCORE_VERSION.apk must exist before publishing to Zapstore."

--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,13 +1,13 @@
 # Zapstore publish config (zsp schema) - https://zapstore.dev/docs/publish
 # Publish with:  SIGN_WITH=<nsec|bunker> zsp publish zapstore.yaml
-# The app id (mybuho.buhogo) and version (1.8.4) are read from the APK below.
+# The app id (mybuho.buhogo) and version (1.9.0) are read from the APK below.
 
 # Source code repository (shown in the app store)
 repository: https://github.com/Buho-Ecosystem/Buho_go
 
 # Where to fetch the APK. A local path lets us ship the local icon and
 # screenshots below. Bump this filename on each release.
-release_source: ./output/BuhoGO_v1_8_4.apk
+release_source: ./output/BuhoGO_v1_9_0.apk
 
 # ---------------------------------------------------------------------------
 # App metadata


### PR DESCRIPTION
Version bump for the 1.9.0 release, kept separate from the feature work already on `dev`.

## Version bump (`c5cfe20`)

The version lives in six spots across five files:

| File | Change |
| --- | --- |
| `package.json` | `1.8.4` → `1.9.0` |
| `src-capacitor/package.json` | `1.8.4` → `1.9.0` |
| `src-capacitor/android/app/build.gradle` | `versionName 1.9.0`, `versionCode 20` → `21` |
| `src-capacitor/ios/.../project.pbxproj` | `MARKETING_VERSION 1.9.0`, `CURRENT_PROJECT_VERSION 20` → `21` |
| `zapstore.yaml` | header note, and `release_source` → `BuhoGO_v1_9_0.apk` |

The iOS build number is kept level with the Android `versionCode` so a build number means the same thing on both platforms.

Also replaced both package descriptions, which still read *"BuhoGo - A Bitcoin Lightning Wallet for the Web"*. That predates the native Android app and every backend except Lightning. The new wording matches the README tagline and the Zapstore summary, and names what the wallet actually speaks.

## Tooling (`3231593`)

`update-version.sh` only knew about `package.json` and the Android gradle, so it silently left the other three at the old version. That is the drift a bump script exists to prevent, and it is why this bump needed three files done by hand. The script now covers all five.

The two newly-handled files are treated as optional: if the iOS project or `zapstore.yaml` is missing, the script reports a skip instead of failing, since the iOS project is recent and the Zapstore config is release-only tooling.

Verified by running a `1.9.0 → 1.9.1` bump, confirming all five files moved together, then reverting. This second commit is independent of the bump, so it can be dropped if you would rather keep this PR to versions only.

## Before tagging

`./output/BuhoGO_v1_9_0.apk` has to exist before `zsp publish` will work; the script now prints that reminder.