### PR TITLE
fix(lud09): show url successActions, and carry them through batch send

### DIFF
--- a/src/components/BatchSendModal.vue
+++ b/src/components/BatchSendModal.vue
@@ -504,6 +504,27 @@
               </div>
             </div>
 
+            <!--
+              LUD-09 links. One quiet row per recipient that sent one back:
+              who it came from, where it goes, and a tap to open it. Tapping
+              leaves this summary standing so a batch that returns several
+              links can be worked through one at a time.
+            -->
+            <div v-if="linkedResults.length > 0" class="link-list">
+              <div class="link-header">{{ $t('Links from recipients') }}</div>
+              <button
+                v-for="result in linkedResults"
+                :key="result.contact.id"
+                type="button"
+                class="link-item"
+                @click="openResultLink(result)"
+              >
+                <span class="link-name">{{ result.contact.name }}</span>
+                <span class="link-url">{{ formatSuccessActionUrl(result.successAction.url, 28) }}</span>
+                <Icon icon="tabler:external-link" width="15" height="15" class="link-icon" />
+              </button>
+            </div>
+
             <!-- Failed List -->
             <div v-if="failedCount > 0" class="failed-list">
               <div class="failed-header">{{ $t('Failed payments') }}:</div>
@@ -618,6 +639,8 @@ import { useAddressBookStore } from '../stores/addressBook'
 import { useTransactionMetadataStore } from '../stores/transactionMetadata'
 import LightningPaymentService, { resolveLUD17URL } from '../utils/lightning.js'
 import { stripWrapperScheme } from '../utils/addressUtils'
+import { parseSuccessAction, resolveSuccessAction, formatSuccessActionUrl } from '../utils/successAction.js'
+import { openInAppBrowser } from '../utils/inAppBrowser.js'
 import { bech32 } from 'bech32'
 import { getUserFriendlyError, formatInsufficientBalanceBreakdown } from '../utils/userErrors'
 import ContactAvatar from './AddressBook/ContactAvatar.vue'
@@ -855,6 +878,16 @@ const totalSent = computed(() => {
   return paymentResults.value
     .filter(r => r.status === 'success')
     .reduce((sum, r) => sum + r.amount, 0)
+})
+
+/**
+ * Recipients that returned a LUD-09 link (a ticket, a receipt, an invite).
+ * Only the `url` variant earns a place in the summary — a plain message or a
+ * decrypted secret has nothing to act on here and stays on the receipt in
+ * Transaction Details, where every variant is stored.
+ */
+const linkedResults = computed(() => {
+  return paymentResults.value.filter(r => r.successAction?.tag === 'url' && r.successAction.url)
 })
 
 const progressPercent = computed(() => {
@@ -1099,6 +1132,17 @@ function onBeforeHide() {
 // ─────────────────────────────────────────────────────────────
 // Methods - Execution Helpers
 // ─────────────────────────────────────────────────────────────
+/**
+ * Resolve a Lightning address to a payable invoice.
+ *
+ * Returns the LUD-09 `successAction` alongside the invoice because the raw
+ * callback response is the only place it exists — the caller pays a bare
+ * bolt11 and would otherwise never see the recipient's post-payment message.
+ * It is parsed (validated) here and resolved after the payment settles, since
+ * an `aes` secret needs the preimage.
+ *
+ * @returns {Promise<{pr: string, successAction: object|null}>}
+ */
 async function fetchLightningAddressInvoice(address, amountSats) {
   const [username, domain] = address.split('@')
   if (!username || !domain) {
@@ -1140,7 +1184,10 @@ async function fetchLightningAddressInvoice(address, amountSats) {
     throw new Error(invoiceData.reason || 'Invoice error')
   }
 
-  return invoiceData.pr
+  return {
+    pr: invoiceData.pr,
+    successAction: parseSuccessAction(invoiceData.successAction, data.callback),
+  }
 }
 
 // Resolve an LNURL-pay link (bech32 LNURL1… or LUD-17 lnurlp://…) to a payable
@@ -1151,7 +1198,8 @@ async function fetchLightningAddressInvoice(address, amountSats) {
 //   2. fixed-amount links (minSendable === maxSendable) are honored — the
 //      server dictates the amount, so `requestedSats` is overridden by the
 //      fixed amount rather than rejected.
-// Returns { pr, amountSats } so the caller can record the amount actually sent.
+// Returns { pr, amountSats, successAction } so the caller can record the amount
+// actually sent and surface the recipient's LUD-09 message.
 async function fetchLnurlInvoice(lnurl, requestedSats) {
   const clean = stripWrapperScheme(lnurl)
 
@@ -1208,7 +1256,11 @@ async function fetchLnurlInvoice(lnurl, requestedSats) {
     throw new Error(invoiceData.reason || 'Invoice error')
   }
 
-  return { pr: invoiceData.pr, amountSats }
+  return {
+    pr: invoiceData.pr,
+    amountSats,
+    successAction: parseSuccessAction(invoiceData.successAction, data.callback),
+  }
 }
 
 function getActiveWallet() {
@@ -1277,7 +1329,9 @@ async function startBatch() {
     contact,
     amount: getContactAmount(contact),
     status: 'pending',
-    error: null
+    error: null,
+    // LUD-09 message this recipient returned, once the payment settles.
+    successAction: null
   }))
 
   const walletType = getActiveWalletType()
@@ -1297,6 +1351,13 @@ async function startBatch() {
 
     const result = paymentResults.value[i]
     result.status = 'sending'
+
+    // LUD-09: the branches below each record what this recipient returned —
+    // `action` is the parsed successAction (only an LNURL-pay callback carries
+    // one) and `payment` is the settled payment, whose preimage decrypts an
+    // `aes` secret. Both are consumed once, after the branch succeeds.
+    let action = null
+    let payment = null
 
     try {
       if (!provider) {
@@ -1333,8 +1394,10 @@ async function startBatch() {
       // Handle Lightning address type
       else if (addressType === 'lightning') {
         if (walletType === WALLET_TYPES.SPARK) {
-          // Spark has native payLightningAddress
-          await provider.payLightningAddress(address, result.amount)
+          // Spark has native payLightningAddress, which parses the
+          // successAction at its own callback boundary.
+          payment = await provider.payLightningAddress(address, result.amount)
+          action = payment?.successAction || null
           result.status = 'success'
         } else if (walletType === WALLET_TYPES.LNBITS) {
           // LNbits: fetch invoice then pay. Route through ensureLNBitsConnected
@@ -1342,24 +1405,28 @@ async function startBatch() {
           // surfaces cleanly) rather than every remaining payment throwing
           // "wallet is not connected".
           const lnbitsProvider = await walletStore.ensureLNBitsConnected()
-          const invoice = await fetchLightningAddressInvoice(address, result.amount)
-          await lnbitsProvider.payInvoice({ invoice })
+          const { pr: invoice, successAction } = await fetchLightningAddressInvoice(address, result.amount)
+          action = successAction
+          payment = await lnbitsProvider.payInvoice({ invoice })
           result.status = 'success'
         } else if (walletType === WALLET_TYPES.ARKADE) {
           // Arkade pays the LN address via a Boltz submarine swap.
           const arkadeProvider = await walletStore.ensureArkadeConnected()
-          const invoice = await fetchLightningAddressInvoice(address, result.amount)
-          await arkadeProvider.payInvoice({ invoice })
+          const { pr: invoice, successAction } = await fetchLightningAddressInvoice(address, result.amount)
+          action = successAction
+          payment = await arkadeProvider.payInvoice({ invoice })
           result.status = 'success'
         } else if (walletType === WALLET_TYPES.NWC) {
-          // NWC: create service and pay
+          // NWC: create service and pay. Its payLightningAddress parses the
+          // successAction at its own callback boundary.
           const nwcString = getActiveWalletNwcString()
           if (!nwcString) {
             throw new Error('NWC connection not found')
           }
           const lightningService = new LightningPaymentService(nwcString)
           const paymentData = await lightningService.processPaymentInput(address)
-          await lightningService.sendPayment(paymentData, result.amount)
+          payment = await lightningService.sendPayment(paymentData, result.amount)
+          action = payment?.successAction || null
           result.status = 'success'
         } else {
           throw new Error('Unsupported wallet type')
@@ -1380,10 +1447,11 @@ async function startBatch() {
       // resulting invoice has the amount baked in, so every wallet type can
       // settle it the same way: pay the invoice.
       else if (addressType === 'lnurl') {
-        const { pr: invoice, amountSats } = await fetchLnurlInvoice(address, result.amount)
+        const { pr: invoice, amountSats, successAction } = await fetchLnurlInvoice(address, result.amount)
         // Record the amount actually sent — a fixed-amount link overrides the
         // batch amount, so the summary must reflect what really went out.
         result.amount = amountSats
+        action = successAction
 
         if (walletType === WALLET_TYPES.NWC) {
           const nwcString = getActiveWalletNwcString()
@@ -1391,12 +1459,12 @@ async function startBatch() {
             throw new Error('NWC connection not found')
           }
           const lightningService = new LightningPaymentService(nwcString)
-          await lightningService.payInvoice(invoice)
+          payment = await lightningService.payInvoice(invoice)
         } else if (walletType === WALLET_TYPES.LNBITS) {
           const lnbitsProvider = await walletStore.ensureLNBitsConnected()
-          await lnbitsProvider.payInvoice({ invoice })
+          payment = await lnbitsProvider.payInvoice({ invoice })
         } else {
-          await provider.payInvoice({ invoice })
+          payment = await provider.payInvoice({ invoice })
         }
         result.status = 'success'
       } else {
@@ -1408,15 +1476,21 @@ async function startBatch() {
       if (result.status === 'success') {
         await addressBookStore.updateLastUsed(result.contact.id)
 
+        // LUD-09: resolve the recipient's message now that the payment has
+        // settled (an `aes` secret needs the preimage). Never throws — a
+        // decryption failure comes back flagged, not raised.
+        result.successAction = await resolveSuccessAction(action, payment?.preimage)
+
         // Queue a pending metadata link so the tx, once it surfaces in
-        // history, is stamped with the contact/address and marked as a
-        // batch send. Best-effort — a metadata failure must never fail
-        // a payment that already went out.
+        // history, is stamped with the contact/address, the recipient's
+        // message, and marked as a batch send. Best-effort — a metadata
+        // failure must never fail a payment that already went out.
         try {
           await transactionMetadataStore.enqueuePendingContactLink({
             contactId: result.contact.id || null,
             recipientAddress: address,
             amountSats: result.amount,
+            successAction: result.successAction,
             source: 'batch',
             walletId: walletStore.activeWalletId || null,
           })
@@ -1468,6 +1542,17 @@ function retryFailed() {
   selectedContacts.value = failedResults.value.map(r => r.contact)
   step.value = 1
   paymentResults.value = []
+}
+
+/**
+ * Open a recipient's LUD-09 link. The summary stays open on purpose: a batch
+ * can hand back several links, and the user comes straight back for the next
+ * one. openInAppBrowser never navigates this window — it overlays a Custom Tab
+ * on native and opens a new tab on web.
+ */
+function openResultLink(result) {
+  const url = result?.successAction?.url
+  if (url) openInAppBrowser(url)
 }
 </script>
 
@@ -2714,6 +2799,74 @@ function retryFailed() {
 
 .stat-failed {
   color: var(--c-error);
+}
+
+/* LUD-09 links returned by recipients: same block rhythm as the failed list
+   below, in neutral chrome so it reads as an offer rather than a warning. */
+.link-list {
+  width: 100%;
+  text-align: left;
+  background: var(--c-bg2);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.link-header {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--c-text2);
+  margin-bottom: 12px;
+}
+
+.link-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 0;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--c-border);
+  font-family: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.link-item:last-child {
+  border-bottom: none;
+}
+
+.link-item:hover { opacity: 0.75; }
+.link-item:active { opacity: 0.6; }
+.link-item:focus-visible {
+  outline: 2px solid var(--c-success);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.link-name {
+  color: var(--c-text);
+  font-weight: 500;
+  flex-shrink: 0;
+  max-width: 40%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.link-url {
+  color: var(--c-text2);
+  margin-left: auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.link-icon {
+  color: var(--c-text3);
+  flex-shrink: 0;
 }
 
 .failed-list {

--- a/src/components/PaymentConfirmation.vue
+++ b/src/components/PaymentConfirmation.vue
@@ -98,10 +98,10 @@
             class="success-action-card"
             :class="$q.dark.isActive ? 'sa-card-dark' : 'sa-card-light'"
           >
-            <!-- A `url` action is a self-explanatory call to action (its own
-                 description labels the button), so it skips the generic caption. -->
+            <!-- A `url` action without a description is a bare call to action,
+                 so it skips the generic caption. -->
             <div
-              v-if="successAction.tag !== 'url'"
+              v-if="successAction.tag !== 'url' || successAction.description"
               class="success-action-label"
               :class="$q.dark.isActive ? 'text-grey-5' : 'text-grey-6'"
             >
@@ -117,20 +117,28 @@
               {{ successAction.message }}
             </div>
 
-            <!-- url: one elegant tap to open. The link is domain-validated
-                 upstream (same host as the callback just paid), so opening it is
-                 safe; openInAppBrowser opens a new tab on web and an in-app view
+            <!-- url: the recipient's note, then the destination itself on the
+                 pill so the payer sees where the tap leads before taking it.
+                 openInAppBrowser opens a new tab on web and an in-app view
                  (Custom Tab / SFSafariViewController) on native. -->
-            <button
-              v-else-if="successAction.tag === 'url'"
-              type="button"
-              class="success-action-open"
-              :class="$q.dark.isActive ? 'sa-open-dark' : 'sa-open-light'"
-              @click="openSuccessActionUrl"
-            >
-              <span class="success-action-open-label">{{ successAction.description || $t('Open link') }}</span>
-              <Icon icon="tabler:external-link" width="16" height="16" class="success-action-open-icon" />
-            </button>
+            <template v-else-if="successAction.tag === 'url'">
+              <div
+                v-if="successAction.description"
+                class="success-action-text"
+                :class="$q.dark.isActive ? 'text-white' : 'text-grey-9'"
+              >
+                {{ successAction.description }}
+              </div>
+              <button
+                type="button"
+                class="success-action-open"
+                :class="$q.dark.isActive ? 'sa-open-dark' : 'sa-open-light'"
+                @click="openSuccessActionUrl"
+              >
+                <span class="success-action-open-label">{{ successActionUrlLabel }}</span>
+                <Icon icon="tabler:external-link" width="16" height="16" class="success-action-open-icon" />
+              </button>
+            </template>
 
             <!-- aes: decrypted secret (tap to copy), or a graceful failure note -->
             <template v-else-if="successAction.tag === 'aes'">
@@ -236,6 +244,7 @@ import { useWalletStore } from '../stores/wallet';
 import { copySensitive } from '../utils/sensitiveClipboard.js';
 import SuccessCheckmark from './SuccessCheckmark.vue';
 import { openInAppBrowser } from '../utils/inAppBrowser.js';
+import { formatSuccessActionUrl } from '../utils/successAction.js';
 
 export default {
   name: 'PaymentConfirmation',
@@ -387,6 +396,14 @@ export default {
       return this.keepsOpen
         ? this.$t('Done')
         : this.$t('Close Now')
+    },
+    /**
+     * The destination of a LUD-09 `url` action, shortened for the pill. Shown
+     * instead of a generic "Open link" so the payer reads the host before
+     * tapping — the link may point anywhere, not just at the paid service.
+     */
+    successActionUrlLabel() {
+      return formatSuccessActionUrl(this.successAction?.url)
     }
   },
   watch: {
@@ -504,10 +521,10 @@ export default {
      * user can also re-copy later from Transaction Details.
      */
     /**
-     * Open a LUD-09 `url` successAction (e.g. a payment receipt). Domain-
-     * validated upstream (parseSuccessAction pins it to the callback host), so
-     * it can only point back at the service just paid. New tab on web, in-app
-     * view on native.
+     * Open a LUD-09 `url` successAction (a receipt, a group invite, a download).
+     * Scheme-validated upstream to http(s); the destination is on the button the
+     * user tapped, so nothing opens that they haven't read. New tab on web,
+     * in-app view on native.
      */
     openSuccessActionUrl() {
       const url = this.successAction?.url;

--- a/src/i18n/de/index.js
+++ b/src/i18n/de/index.js
@@ -1582,6 +1582,7 @@ export default {
   "failed": "fehlgeschlagen",
   "Total sent": "Gesamt gesendet",
   "sats sent": "Sats gesendet",
+  "Links from recipients": "Links von Empfängern",
   "Failed payments": "Fehlgeschlagene Zahlungen",
   "Retry Failed": "Fehlgeschlagene wiederholen",
   "Cancel Batch?": "Sammelzahlung abbrechen?",

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -1538,6 +1538,7 @@ export default {
   "failed": "failed",
   "Total sent": "Total sent",
   "sats sent": "sats sent",
+  "Links from recipients": "Links from recipients",
   "Failed payments": "Failed payments",
   "Retry Failed": "Retry Failed",
   "Cancel Batch?": "Cancel Batch?",

--- a/src/i18n/es/index.js
+++ b/src/i18n/es/index.js
@@ -1583,6 +1583,7 @@ export default {
   "failed": "fallidos",
   "Total sent": "Total enviado",
   "sats sent": "sats enviados",
+  "Links from recipients": "Enlaces de destinatarios",
   "Failed payments": "Pagos fallidos",
   "Retry Failed": "Reintentar Fallidos",
   "Cancel Batch?": "¿Cancelar Envío?",

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -313,17 +313,22 @@
               {{ currentSuccessAction.message }}
             </div>
 
-            <!-- url: one elegant tap to open (new tab on web, in-app view on
-                 native). Domain-validated upstream to the callback host. -->
-            <button
-              v-else-if="currentSuccessAction.tag === 'url'"
-              type="button"
-              class="sa-detail-open"
-              @click="openSuccessActionUrl(currentSuccessAction.url)"
-            >
-              <span class="sa-detail-open-label">{{ currentSuccessAction.description || $t('Open link') }}</span>
-              <Icon icon="tabler:external-link" width="16" height="16" class="sa-detail-open-icon" />
-            </button>
+            <!-- url: the recipient's note, then the destination itself on the
+                 pill so the link target is readable before it is opened (new tab
+                 on web, in-app view on native). -->
+            <template v-else-if="currentSuccessAction.tag === 'url'">
+              <div v-if="currentSuccessAction.description" class="sa-detail-text">
+                {{ currentSuccessAction.description }}
+              </div>
+              <button
+                type="button"
+                class="sa-detail-open"
+                @click="openSuccessActionUrl(currentSuccessAction.url)"
+              >
+                <span class="sa-detail-open-label">{{ successActionUrlLabel }}</span>
+                <Icon icon="tabler:external-link" width="16" height="16" class="sa-detail-open-icon" />
+              </button>
+            </template>
 
             <!-- aes: decrypted secret (tap to copy) -->
             <template v-else-if="currentSuccessAction.tag === 'aes'">
@@ -684,6 +689,7 @@ import { matchLnAddressService } from '../services/lnAddressServices';
 import { shareContent } from '../utils/share';
 import { copySensitive } from '../utils/sensitiveClipboard.js';
 import { openInAppBrowser } from '../utils/inAppBrowser.js';
+import { formatSuccessActionUrl } from '../utils/successAction.js';
 import { pollVerify } from '../utils/lnurlVerify.js';
 import { Icon } from '@iconify/vue';
 import ContactAvatar from '../components/AddressBook/ContactAvatar.vue';
@@ -891,6 +897,14 @@ export default {
       if (!this.transaction || !this.metadataStore) return null;
       if (this.transaction.type !== 'outgoing') return null;
       return this.metadataStore.getSuccessActionForTransaction(this.transaction.id, this.metadataWalletId);
+    },
+
+    /**
+     * Destination of a LUD-09 `url` action, shortened for the pill so the link
+     * target stays readable here as well as on the success sheet.
+     */
+    successActionUrlLabel() {
+      return formatSuccessActionUrl(this.currentSuccessAction?.url);
     },
 
     /**
@@ -1679,8 +1693,9 @@ export default {
       }
     },
 
-    // Open a LUD-09 `url` successAction (e.g. a payment receipt). Domain-
-    // validated upstream, so it only points back at the service that was paid.
+    // Open a LUD-09 `url` successAction (a receipt, a group invite, a download).
+    // Scheme-validated upstream to http(s), and the destination is printed on the
+    // button itself, so nothing opens the user hasn't read.
     // New tab on web, in-app view (Custom Tab / SFSafariViewController) on native.
     openSuccessActionUrl(url) {
       if (url) openInAppBrowser(url);

--- a/src/utils/__tests__/successAction.spec.js
+++ b/src/utils/__tests__/successAction.spec.js
@@ -22,6 +22,7 @@ import {
   parseSuccessAction,
   resolveSuccessAction,
   decryptAesSuccessAction,
+  formatSuccessActionUrl,
   SUCCESS_ACTION_MAX_CHARS,
 } from '../successAction.js';
 
@@ -100,7 +101,7 @@ await test('parse: clamps message to the spec cap', () => {
   );
 });
 
-await test('parse: url accepts http(s) on the callback domain, rejects other schemes', () => {
+await test('parse: url accepts http(s), rejects other schemes', () => {
   const cb = 'https://ex.com/lnurlp/callback';
   assert.deepEqual(
     parseSuccessAction({ tag: 'url', description: 'Receipt', url: 'https://ex.com/r/1' }, cb),
@@ -109,24 +110,37 @@ await test('parse: url accepts http(s) on the callback domain, rejects other sch
   assert.equal(parseSuccessAction({ tag: 'url', url: 'ftp://x' }, cb), null);
   assert.equal(parseSuccessAction({ tag: 'url', url: 'not a url' }, cb), null);
   assert.equal(parseSuccessAction({ tag: 'url', url: 'javascript:alert(1)' }, cb), null);
+  assert.equal(parseSuccessAction({ tag: 'url', url: 'data:text/html,<script>' }, cb), null);
 });
 
-await test('parse: url enforces the LUD-09 same-domain rule', () => {
-  // Different domain than the callback → degrade to the description as a message.
+await test('parse: url off the callback domain survives as a link', () => {
+  // The real-world case this regressed on: a ticket paid at one host that
+  // links to the group chat it grants access to. LUD-09's same-domain line is
+  // not enforced — the UI shows the destination and requires a tap instead.
   assert.deepEqual(
     parseSuccessAction(
-      { tag: 'url', description: 'See details', url: 'https://evil.com/x' },
+      { tag: 'url', description: 'Join the group', url: 'https://t.me/somegroup' },
       'https://ex.com/cb',
     ),
-    { tag: 'message', message: 'See details' },
+    { tag: 'url', description: 'Join the group', url: 'https://t.me/somegroup' },
   );
-  // Different domain, no description → dropped entirely.
-  assert.equal(
-    parseSuccessAction({ tag: 'url', url: 'https://evil.com/x' }, 'https://ex.com/cb'),
-    null,
+  // No description and no callback are both fine; the link still stands alone.
+  assert.deepEqual(
+    parseSuccessAction({ tag: 'url', url: 'https://ex.com/x' }),
+    { tag: 'url', description: '', url: 'https://ex.com/x' },
   );
-  // No callback to validate against → fails closed.
-  assert.equal(parseSuccessAction({ tag: 'url', url: 'https://ex.com/x' }), null);
+});
+
+await test('format: url label drops the scheme and keeps the host visible', () => {
+  assert.equal(formatSuccessActionUrl('https://t.me/lnPoS_Kassenterminal'), 't.me/lnPoS_Kassenterminal');
+  assert.equal(formatSuccessActionUrl('https://shop.example.com/'), 'shop.example.com');
+  assert.equal(formatSuccessActionUrl(''), '');
+  assert.equal(formatSuccessActionUrl(null), '');
+
+  const long = formatSuccessActionUrl(`https://shop.example.com/orders/${'a'.repeat(120)}/receipt`);
+  assert.ok(long.startsWith('shop.example.com'), `host kept: ${long}`);
+  assert.ok(long.includes('…'), `ellipsized: ${long}`);
+  assert.ok(long.length <= 42, `within budget: ${long.length}`);
 });
 
 await test('parse: aes requires ciphertext + iv', () => {

--- a/src/utils/lnurlVerify.js
+++ b/src/utils/lnurlVerify.js
@@ -24,11 +24,12 @@ export function validateVerifyUrl(verifyUrl, callbackUrl) {
   if (typeof verifyUrl !== 'string' || !verifyUrl) return null
   try {
     const v = new URL(verifyUrl)
-    // https only (post-payment polling), and the same host as the callback —
-    // the same "same-domain" rule LUD-09 applies to `url` successActions
-    // (see sameDomain() in successAction.js), compared by hostname so it is
-    // port-insensitive. Fails closed on a missing/unparseable callback so we
-    // can never be tricked into polling a third-party URL.
+    // https only (post-payment polling), and the same host as the callback,
+    // compared by hostname so it is port-insensitive. Fails closed on a
+    // missing/unparseable callback so we can never be tricked into polling a
+    // third-party URL. Unlike a LUD-09 `url` successAction — a link the user
+    // reads and taps — this one the app calls by itself, so the host stays
+    // pinned to the service just paid.
     if (v.protocol !== 'https:') return null
     const c = new URL(callbackUrl)
     if (v.hostname !== c.hostname) return null

--- a/src/utils/successAction.js
+++ b/src/utils/successAction.js
@@ -67,16 +67,26 @@ function isHttpUrl(value) {
 }
 
 /**
- * Whether two URLs share the same host — the LUD-09 rule that a `url`
- * successAction must live on the same domain as the LNURL callback. An
- * unparseable or missing callback fails closed (treated as a mismatch).
+ * Shorten a `url` action's link for display: drop the scheme and any trailing
+ * slash, and ellipsize the middle when it is too long for one line. The host
+ * always stays visible — it is the part that tells the payer where they are
+ * about to go.
+ *
+ * @param {string} url
+ * @param {number} [max=42] target length of the returned label
+ * @returns {string}
  */
-function sameDomain(a, b) {
-  try {
-    return new URL(a).hostname === new URL(b).hostname;
-  } catch {
-    return false;
-  }
+export function formatSuccessActionUrl(url, max = 42) {
+  if (typeof url !== 'string' || !url) return '';
+  const trimmed = url.trim().replace(/^https?:\/\//i, '').replace(/\/+$/, '');
+  if (trimmed.length <= max) return trimmed;
+  const slash = trimmed.indexOf('/');
+  const host = slash === -1 ? trimmed : trimmed.slice(0, slash);
+  // Keep the host intact and eat into the path; a host longer than the budget
+  // is simply truncated at the end.
+  const room = max - host.length - 1;
+  if (room < 4) return `${trimmed.slice(0, max - 1)}…`;
+  return `${host}…${trimmed.slice(trimmed.length - room + 1)}`;
 }
 
 /**
@@ -85,19 +95,27 @@ function sameDomain(a, b) {
  *
  * Strict by design: the object arrives from a remote server, so we whitelist
  * the three LUD-09 tags, clamp free text, and reject a `url` that isn't
- * http(s). Per LUD-09 a `url`'s domain MUST equal the `callback` domain; a
- * mismatch is degraded to its description (a plain message) rather than shown
- * as a link. The `aes` ciphertext/iv are kept verbatim for later decryption.
+ * http(s) — `javascript:`, `data:` and friends never reach the UI. The `aes`
+ * ciphertext/iv are kept verbatim for later decryption.
+ *
+ * On the `url` variant we deliberately do NOT enforce LUD-09's "url domain
+ * must equal the callback domain" line. Real recipients routinely link away
+ * from the host that served the invoice (a ticket paid at a shop pointing to
+ * the group chat it grants access to), and every widely used wallet shows
+ * those links, so enforcing it hides legitimate content and looks like a bug.
+ * The payer is protected instead by the UI contract: the link is never
+ * followed automatically, the actual destination is rendered next to the
+ * button, and opening it takes a deliberate tap.
  *
  * @param {any} raw
  * @param {string} [callbackUrl] the LNURL-pay `callback` the invoice came from,
- *   used to enforce the LUD-09 same-domain rule on a `url` action.
+ *   kept in the signature for callers and future provenance checks.
  * @returns {null
  *   | {tag:'message', message:string}
  *   | {tag:'url', description:string, url:string}
  *   | {tag:'aes', description:string, ciphertext:string, iv:string}}
  */
-export function parseSuccessAction(raw, callbackUrl) {
+export function parseSuccessAction(raw, callbackUrl) { // eslint-disable-line no-unused-vars
   if (!raw || typeof raw !== 'object') return null;
 
   switch (raw.tag) {
@@ -108,15 +126,7 @@ export function parseSuccessAction(raw, callbackUrl) {
     case 'url': {
       const url = typeof raw.url === 'string' ? raw.url.trim() : '';
       if (!isHttpUrl(url)) return null;
-      const description = clampText(raw.description);
-      // LUD-09: the url's domain MUST equal the LNURL `callback` domain. A
-      // mismatch is a phishing vector (a merchant pointing the payer at an
-      // unrelated site), so we refuse to surface it as a link — degrade to the
-      // description as a plain message, or drop it entirely.
-      if (!sameDomain(url, callbackUrl)) {
-        return description ? { tag: 'message', message: description } : null;
-      }
-      return { tag: 'url', description, url };
+      return { tag: 'url', description: clampText(raw.description), url };
     }
     case 'aes': {
       const ciphertext = typeof raw.ciphertext === 'string' ? raw.ciphertext.trim() : '';


### PR DESCRIPTION
Discovered by @AxelHamburch 

## Problem

A `url` successAction whose host differed from the LNURL-pay callback host was downgraded to a plain message before it reached the UI, so the link was never shown.

Reproduced against a live pay link (callback `21mio.space`, link `t.me`):

```json
{
  "tag": "url",
  "url": "https://t.me/MyGroup",
  "description": "Danke für die Zahlung. 🧡 Über den URL-Link kommst du zur Gruppe."
}
```

Before: only the description rendered. Other wallets show the link.

Batch send had a second, separate gap: it fetches its own invoices and threw the callback's `successAction` away entirely, so a ticket link or receipt was lost for every payment made that way.

## Change

**Parsing**

- `parseSuccessAction` keeps the link regardless of host. LUD-09 asks for host equality, but recipients routinely link away from the host that served the invoice, so enforcing it hides legitimate content.
- Safety moves to the interaction: http(s) only (`javascript:` / `data:` still rejected), nothing opens on its own, and the destination is printed on the button that opens it.
- `formatSuccessActionUrl()` is the one place link labels are formatted (scheme stripped, middle-ellipsized so the host always survives).
- LUD-21 `verify` stays strictly same-domain, since the app polls that URL itself.

**Surfaces**

- Send success sheet and the stored receipt in Transaction Details now show the note as text and the link as a pill labelled with the destination.
- Batch send parses the action in both of its fetch helpers, keeps what the Spark and NWC providers already parsed, and passes it into the pending metadata link it was queueing anyway, so it lands on each recipient's receipt.
- The batch summary lists recipients that sent a link back (name, destination, one tap to open). Opening one leaves the summary standing so several can be worked through in turn. Plain messages and secrets stay off that list and remain on the receipt.

## Coverage

All four backends already parsed LUD-09 on both LNURL paths (Spark, NWC, LNbits, Arkade) - the shared parser was the single choke point. Plain BOLT11 sends carry no successAction by definition. Auto-withdraw still ignores it on purpose (background sweep to your own payout address, no payer present); kiosk is receive-side, where LUD-09 does not apply.

