### PR TITLE
feat(balance): show last known balance instantly on cold start

### DIFF
--- a/src/pages/Wallet.vue
+++ b/src/pages/Wallet.vue
@@ -230,7 +230,10 @@
                 :prefix="balancePrefix"
                 :suffix="balanceSuffix"
                 class="amount-number"
-                :class="$q.dark.isActive ? 'amount-number-dark' : 'amount-number-light'"
+                :class="[
+                  $q.dark.isActive ? 'amount-number-dark' : 'amount-number-light',
+                  { 'amount-number--provisional': balanceProvisional },
+                ]"
                 :spin-timing="{ duration: 750, easing: 'cubic-bezier(0.16, 1, 0.3, 1)' }"
                 :transform-timing="{ duration: 750, easing: 'cubic-bezier(0.16, 1, 0.3, 1)' }"
               />
@@ -242,6 +245,7 @@
               <span v-if="walletStore.balanceHidden" class="secondary-amount-display">
                 <span class="secondary-value">••••</span>
               </span>
+              <span v-else-if="balanceProvisional" class="loading-secondary">{{ $t('Updating') }}...</span>
               <span v-else-if="secondaryValue" class="secondary-amount-display">
                 <span class="secondary-value">{{ secondaryValue }}</span>
               </span>
@@ -848,6 +852,7 @@ import {classifyTransportFailure} from '../utils/userErrors.js';
 import {buildLnurlPayCallbackUrl} from '../utils/lnurlPay.js';
 import {isLightningInvoice as isLightningInvoiceShared, stripWrapperScheme} from '../utils/addressUtils.js';
 import {canWalletPay, walletSwitchHint} from '../utils/walletCapabilities.js';
+import {readPersistedWalletState} from '../utils/walletHydration.js';
 import {zapInfoFromTx} from '../utils/zaps.js';
 import {zapperDisplayName, zapperPicture} from '../services/zapperProfiles.js';
 import {NOSTRICH_HEAD_ICON} from '../utils/nostrIcon.js';
@@ -970,7 +975,7 @@ export default {
       isMigrating: false,
 
       walletState: {
-        balance: 312,
+        balance: 0,
         connectedWallets: [],
         activeWalletId: null,
         currency: 'sats',
@@ -988,6 +993,12 @@ export default {
       // computed properties.
       lastTransaction: null,
       isLoadingLastTransaction: true,
+
+      // True while the shown balance is the persisted cache from the last
+      // session, before the first authoritative fetch lands. Drives the
+      // dimmed amount + "Updating..." secondary line. Display only — no
+      // spend/max logic ever reads walletState.balance while provisional.
+      balanceProvisional: false,
 
       showReceiveModal: false,
       showSendModal: false,
@@ -3233,6 +3244,11 @@ export default {
     },
     async initializeWallet() {
       try {
+        // A returning user has a cached balance from the last session —
+        // paint it immediately (marked provisional) instead of holding the
+        // whole screen on a skeleton until the wallet has connected.
+        this.seedBalanceFromCache();
+
         await this.loadWalletState();
 
         // Initialize wallet store
@@ -3312,9 +3328,27 @@ export default {
         } catch (error) {
           console.error('Failed to load wallet state:', error);
         }
-      } else {
-        this.walletState.balance = 312;
       }
+    },
+
+    /**
+     * Seed the balance display from the wallet store's persisted
+     * `metadata.cachedBalance` of the active wallet, written on every
+     * successful balance fetch. When a value exists the skeleton is
+     * skipped and the amount renders provisionally until the first live
+     * fetch replaces it. A fresh install has no snapshot and keeps
+     * today's skeleton behaviour.
+     */
+    seedBalanceFromCache() {
+      const saved = readPersistedWalletState();
+      const active = saved?.wallets?.find?.((w) => w?.id === saved?.activeWalletId);
+      const cached = active?.metadata?.cachedBalance;
+      if (typeof cached !== 'number' || !Number.isFinite(cached)) return false;
+
+      this.walletState.balance = cached;
+      this.balanceProvisional = true;
+      this.showLoadingScreen = false;
+      return true;
     },
 
     /**
@@ -3326,7 +3360,7 @@ export default {
      * own fetch — so the last-transaction refresh lives in `finally` to
      * guarantee it runs for every wallet type, even when a branch throws.
      */
-    async updateWalletBalance() {
+    async updateWalletBalance(opts = {}) {
       try {
         if (this.showLoadingScreen) {
           // still initializing
@@ -3335,16 +3369,33 @@ export default {
         const awStore = useAutoWithdrawStore();
         const activeWalletId = this.walletStore.activeWalletId;
 
+        // The cached read is display-only by hard rule: it must never feed
+        // auto-withdraw (a money decision), so a wallet with auto-withdraw
+        // enabled keeps authoritative fetches even on the periodic tick.
+        const preferCached = Boolean(opts.preferCached)
+          && !awStore.getConfig(activeWalletId)?.enabled;
+
         // Check if active wallet is Spark
         if (this.walletStore.isActiveWalletSpark) {
           // Try to get connected provider, auto-reconnects if session PIN available
           try {
             const provider = await this.walletStore.ensureSparkConnected();
-            const balanceResult = await provider.getBalance();
+            let balanceResult = preferCached && typeof provider.getCachedBalance === 'function'
+              ? await provider.getCachedBalance()
+              : await provider.getBalance();
+            // The SDK cache starts empty until the event stream has synced;
+            // a cached zero while we are showing funds means "not warmed
+            // yet", not "empty wallet" — re-read authoritatively rather
+            // than flashing 0.
+            if (preferCached && balanceResult.balance === 0 && this.walletState.balance > 0) {
+              balanceResult = await provider.getBalance();
+            }
             this.walletState.balance = balanceResult.balance;
+            this.balanceProvisional = false;
             localStorage.setItem('buhoGO_wallet_state', JSON.stringify(this.walletState));
 
-            // Auto-withdraw check
+            // Auto-withdraw check (never reachable from a cached read: an
+            // enabled config forces the authoritative branch above)
             if (balanceResult.balance > 0 && activeWalletId) {
               awStore.checkAndExecute(activeWalletId, balanceResult.balance, this.walletStore);
             }
@@ -3381,6 +3432,7 @@ export default {
             const provider = await this.walletStore.ensureLNBitsConnected();
             const balanceResult = await provider.getBalance();
             this.walletState.balance = balanceResult.balance;
+            this.balanceProvisional = false;
 
             // Update wallet in store
             const activeWallet = this.walletState.connectedWallets.find(
@@ -3412,6 +3464,7 @@ export default {
             const provider = await this.walletStore.ensureArkadeConnected();
             const balanceResult = await provider.getBalance();
             this.walletState.balance = balanceResult.balance;
+            this.balanceProvisional = false;
 
             const activeWallet = this.walletState.connectedWallets.find(
               w => w.id === this.walletState.activeWalletId
@@ -3444,6 +3497,7 @@ export default {
           await nwc.enable();
           const balance = await nwc.getBalance();
           this.walletState.balance = balance.balance;
+          this.balanceProvisional = false;
           activeWallet.balance = balance.balance;
 
           localStorage.setItem('buhoGO_wallet_state', JSON.stringify(this.walletState));
@@ -3592,7 +3646,9 @@ export default {
       this.refreshInterval = setInterval(async () => {
         // updateWalletBalance refreshes the last-tx card in its finally
         // block, so we don't call loadLastTransaction separately here.
-        await this.updateWalletBalance();
+        // The tick prefers the SDK's event-stream-backed balance cache;
+        // authoritative fetches stay on the post-send/receive paths.
+        await this.updateWalletBalance({ preferCached: true });
         await this.loadFiatRates();
         // Keep the profile pill honest while the app remains open: a payment
         // to the user's public name can arrive without touching a wallet.
@@ -6685,6 +6741,12 @@ export default {
   font-weight: 800;
   line-height: 1;
   font-family: 'Manrope', sans-serif;
+  transition: opacity 0.3s ease;
+}
+
+/* Cached last-session figure shown before the first live fetch lands */
+.amount-number--provisional {
+  opacity: 0.55;
 }
 
 .amount-number-dark {

--- a/src/providers/SparkWalletProvider.js
+++ b/src/providers/SparkWalletProvider.js
@@ -467,6 +467,32 @@ export class SparkWalletProvider extends WalletProvider {
     }
   }
 
+  /**
+   * Balance from the SDK's in-memory cache — no network round trip. The
+   * cache is kept current by the wallet's event stream, but it starts
+   * empty on a fresh connection, so callers that need a number before the
+   * first sync must bring their own fallback. Shape-compatible with
+   * getBalance(); display use only — spend/max logic must keep reading
+   * getBalance().
+   */
+  async getCachedBalance() {
+    this._ensureConnected();
+
+    try {
+      const result = await this.wallet.getCachedBalance();
+      const available = result?.satsBalance?.available ?? result?.balance ?? 0n;
+
+      return {
+        balance: Number(available),
+        pending: Number(result?.satsBalance?.incoming ?? 0n),
+        tokenBalances: result?.tokenBalances || []
+      };
+    } catch (error) {
+      this.setError(error);
+      throw error;
+    }
+  }
+
   async getInfo() {
     this._ensureConnected();
 


### PR DESCRIPTION
Closes #226. Independent of #241 (`getCachedBalance` verified present in the 0.7.17 type declarations, so this works with or without the SDK bump).

**What**
- Cold start paints the last session's balance immediately instead of a skeleton: seeded from the active wallet's persisted `metadata.cachedBalance` (written on every successful balance fetch), read through the shared `readPersistedWalletState()` snapshot helper. Rendered provisionally: dimmed amount + "Updating..." in the secondary line, then NumberFlow animates to the live figure when the first authoritative fetch lands. Fresh installs have no snapshot and keep today's skeleton.
- The 30s periodic tick prefers the SDK's event-stream-backed cache via a new `SparkWalletProvider.getCachedBalance()` (shape-compatible with `getBalance()`). Post-send/receive and wallet-switch refreshes stay authoritative.
- The hardcoded `312` placeholder fallback is gone.

**Hard rules, enforced in code**
- Cached values are display-only. A wallet with auto-withdraw enabled forces the authoritative branch even on the tick, and `checkAndExecute` can never be fed from a cached read.
- A cached zero while funds are on screen reads as "cache not warmed yet", not "empty wallet": the tick re-reads authoritatively instead of flashing 0.
- Spend/max logic is untouched; nothing on the send path reads the provisional value.

Out of scope per the issue: kiosk (own boot path, stays on live balance).

**Verified**: `npm test` green, `quasar build` clean. On-device: cold start with a funded Spark wallet should show the dimmed cached figure sub-second, then settle to live.
