### PR TITLE
fix(pwa): a tab that outlived its build refreshes instead of going blank

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,41 @@
       })();
     </script>
 
+
+    <!--
+      Last-resort refresh when the entry bundle is missing.
+
+      Deploys are atomic, so the previous build's hashed files are gone the
+      moment a new one is live. A browser (or service worker) still holding the
+      old index.html then asks for a script that 404s, and if it is the entry
+      bundle, nothing in the app is running to notice — the page just stays
+      blank. Catch the load failure here and refresh onto the current deploy.
+
+      src/utils/chunkReload.js handles every failure that happens after the app
+      is up and shares the storage key below, so the two together refresh at
+      most once before letting the failure stand.
+    -->
+    <script>
+      (function () {
+        var MARK = 'buhogo:chunk-reload-at';
+        var COOLDOWN_MS = 30000;
+        window.addEventListener('error', function (event) {
+          var el = event.target;
+          if (!el || el.tagName !== 'SCRIPT' || !el.src) return;
+          if (el.src.indexOf('/assets/') === -1) return;
+          if (navigator.onLine === false) return;
+          try {
+            var at = Number(window.sessionStorage.getItem(MARK));
+            if (at > 0 && Date.now() - at < COOLDOWN_MS) return;
+            window.sessionStorage.setItem(MARK, String(Date.now()));
+          } catch (e) {
+            return;
+          }
+          window.location.reload();
+        }, true); // resource errors do not bubble, so listen on the way down
+      })();
+    </script>
+
 </head>
 <body>
 <!-- quasar:entry-point -->

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -15,6 +15,9 @@ export default defineConfig((ctx) => {
       // 'theme' runs first so the persisted light/dark choice is applied
       // before any component renders — avoids a flash of the wrong theme.
       'theme',
+      // 'chunk-recovery' installs the missing-chunk refresh as early as it can,
+      // so a tab left open across a deploy recovers rather than going blank.
+      'chunk-recovery',
       'axios',
       'i18n',
       'iconify',

--- a/src/boot/chunk-recovery.js
+++ b/src/boot/chunk-recovery.js
@@ -1,0 +1,38 @@
+import { boot } from 'quasar/wrappers'
+import { reloadForChunkError } from 'src/utils/chunkReload'
+
+/**
+ * Chunk-recovery boot — catches the dynamic imports the router does not.
+ *
+ * `Router.onError` in `src/router/index.js` covers lazy route components, but
+ * plenty of the app is code-split below that level: modals, wallet backends,
+ * the heavier libraries pulled in on demand. When one of those imports fails
+ * because the deploy moved underneath an open tab, the rejection surfaces
+ * either through Vue's error handler or as an unhandled rejection, never
+ * through the router. Both roads lead to `reloadForChunkError`, which decides
+ * whether a refresh is the right answer and is the single place holding the
+ * one-attempt budget. See `src/utils/chunkReload.js` for the reasoning.
+ *
+ * Anything that is not a missing chunk is passed straight through untouched,
+ * so this adds a recovery path without swallowing errors.
+ *
+ * Registered in `quasar.config.js` under `boot: [...]`. Loaded everywhere,
+ * kiosk included — it no-ops on the native build.
+ */
+export default boot(({ app }) => {
+  const previousHandler = app.config.errorHandler
+
+  app.config.errorHandler = (error, instance, info) => {
+    if (reloadForChunkError(error)) return
+
+    if (previousHandler) {
+      previousHandler(error, instance, info)
+      return
+    }
+    console.error('Unhandled app error:', error, info)
+  }
+
+  window.addEventListener('unhandledrejection', event => {
+    reloadForChunkError(event.reason)
+  })
+})

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,7 @@
 import { defineRouter } from '#q-app/wrappers'
 import { createRouter, createMemoryHistory, createWebHistory, createWebHashHistory } from 'vue-router'
 import routes from './routes'
+import { reloadForChunkError } from 'src/utils/chunkReload'
 
 /*
  * If not building with SSR mode, you can
@@ -24,6 +25,13 @@ export default defineRouter(function (/* { store, ssrContext } */) {
     // quasar.conf.js -> build -> vueRouterMode
     // quasar.conf.js -> build -> publicPath
     history: createHistory(process.env.VUE_ROUTER_BASE)
+  })
+
+  // A lazy route component that 404s is almost always a tab that outlived its
+  // build, not a broken route. Refresh onto the current deploy instead of
+  // leaving the user on a blank screen. See src/utils/chunkReload.js.
+  Router.onError(error => {
+    reloadForChunkError(error)
   })
 
   return Router

--- a/src/utils/chunkReload.js
+++ b/src/utils/chunkReload.js
@@ -1,0 +1,88 @@
+import { Capacitor } from '@capacitor/core'
+
+/**
+ * Recovery for a tab that outlived the build it was loaded from.
+ *
+ * Every deploy hashes the JS chunks into fresh filenames, and hosting is
+ * atomic: the previous build's files stop existing the moment the new one goes
+ * live. So a tab that has been open across a deploy — or a service worker
+ * still serving the index.html it precached earlier — keeps asking for chunk
+ * names that are gone. The first lazy import after the deploy 404s, the route
+ * never renders, and the user is left looking at a blank screen with no way to
+ * know a refresh is all it needs.
+ *
+ * A reload fetches the new index.html and the matching chunks, so do that
+ * reload on the user's behalf. It is deliberately guarded: one attempt, then
+ * the error is allowed through. A reload loop is worse than a blank page, and
+ * a chunk that stays missing after a refresh is a real failure the user (and
+ * the console) should see rather than a skew we can paper over.
+ *
+ * Wired in two places, both of which see failures the other does not:
+ *   - `src/router/index.js` via `Router.onError`, for lazy route components
+ *   - `src/boot/chunk-recovery.js`, for dynamic imports outside the router
+ * A third, cruder copy of the same guard sits inline in `index.html` for the
+ * case where the entry bundle itself 404s and none of this code is running.
+ * Its storage key is the one below — keep them identical so the layers share a
+ * single reload budget instead of each spending their own.
+ */
+
+const RELOAD_MARK = 'buhogo:chunk-reload-at'
+const RELOAD_COOLDOWN_MS = 30000
+
+// A missing chunk reads differently in every engine, and none of them set a
+// useful `name`, so matching the message is the only portable signal.
+const CHUNK_ERROR_PATTERNS = [
+  'failed to fetch dynamically imported module', // Chromium
+  'error loading dynamically imported module', // Firefox
+  'importing a module script failed', // Safari
+  'unable to preload css', // Vite's preload helper, same cause
+  'loading chunk' // ChunkLoadError's own wording
+]
+
+export function isChunkLoadError (error) {
+  if (!error) return false
+  if (error.name === 'ChunkLoadError') return true
+  const message = String(error.message || error).toLowerCase()
+  return CHUNK_ERROR_PATTERNS.some(pattern => message.includes(pattern))
+}
+
+function alreadyReloaded () {
+  try {
+    const at = Number(window.sessionStorage.getItem(RELOAD_MARK))
+    return at > 0 && Date.now() - at < RELOAD_COOLDOWN_MS
+  } catch (e) {
+    // Storage can throw in locked-down browser modes. Without a memory of the
+    // attempt there is no way to promise we would stop after one, so treat the
+    // budget as already spent.
+    return true
+  }
+}
+
+/**
+ * Reload once if `error` is a missing-chunk error. Returns true when the
+ * reload was triggered, so callers know the error has been handled and does
+ * not need reporting on top.
+ */
+export function reloadForChunkError (error) {
+  if (!isChunkLoadError(error)) return false
+
+  // The packaged Android build serves its chunks from inside the app, so they
+  // can never be out of step with the document that asked for them. A chunk
+  // error there means something else entirely and a reload would only hide it.
+  if (Capacitor.isNativePlatform()) return false
+
+  // Offline, the chunk is missing because the network is, not because the
+  // build moved. Reloading would trade a half-working app shell for nothing.
+  if (navigator.onLine === false) return false
+
+  if (alreadyReloaded()) return false
+
+  try {
+    window.sessionStorage.setItem(RELOAD_MARK, String(Date.now()))
+  } catch (e) {
+    return false
+  }
+
+  window.location.reload()
+  return true
+}


### PR DESCRIPTION
## The bug

`go.mybuho.de` served a blank page, with this in the console:

```
Failed to load resource: the server responded with a status of 404 () (wallet-rGA-tIB_.js)
```

The deploy itself was healthy. The live `index.html` referenced `/assets/wallet-keYFSQkv.js`, which served fine; `wallet-rGA-tIB_.js` was the same chunk from an *earlier* build. Deploys are atomic and the chunks are content-hashed, so the previous build's files stop existing the moment a new one goes live. A tab left open across a deploy, or a service worker still serving the `index.html` it precached earlier, keeps asking for names that are gone. The first lazy import after the deploy 404s, the route never renders, and there is nothing on screen to suggest that a refresh fixes it. It cleared itself after about five minutes, once the HTML revalidated.

This hits every user with the PWA open across a deploy, not just the one who reported it.

## The fix

Refresh for them, at three layers, because each sees failures the others do not:

| Layer | Covers |
| --- | --- |
| `Router.onError` | Lazy route components. The path this report took. |
| `src/boot/chunk-recovery.js` | Code-split modals, wallet backends and libraries pulled in below the router, via Vue's error handler and `unhandledrejection`. |
| Inline script in `index.html` | The entry bundle itself 404ing, where no bundled code is running to notice. |

All three route into `src/utils/chunkReload.js`, which holds a single reload budget: one attempt per 30s, shared, keyed in `sessionStorage`. A reload loop is worse than a blank page, and a chunk still missing after a refresh is a real failure that belongs in the console rather than papered over.

It stands down in three cases:

- **Native.** The packaged Android build ships its chunks with the document that asks for them, so they can never be out of step. A chunk error there means something else, and refreshing would only hide it.
- **Offline.** The network is the reason, not the build. Refreshing trades a half-working app shell for nothing.
- **No storage.** If `sessionStorage` throws, there is no way to promise we would stop after one attempt, so the budget counts as spent.

Non-chunk errors pass through untouched; the boot file chains any existing handler rather than replacing it.

## Verification

Built the PWA, deleted `WelcomePage-BJNakGKy.js` from `dist/pwa/assets`, and loaded it against a local server:

- Chunk 404 → **exactly one** reload, then it stopped, with the chunk permanently gone. No loop.
- Storage mark set once; subsequent failures declined to reload.
- Chunk restored and mark cleared → app renders normally, no reload, mark stays `null`. No false positives on a healthy load.

## Note for review

`src/main.js` already contained a `ChunkLoadError → location.reload()` in `AppErrorHandler`, which is probably why this looked handled. That file is dead code: Quasar generates its own entry, and none of its strings appear in the built bundle. Its version also had no loop guard, and its global listeners `preventDefault()` every error and rejection. Left untouched here; worth deleting separately.

## Base branch

Opened against `main` as asked. The usual convention is `dev`, so retarget if that was not deliberate.
